### PR TITLE
remove discord bot token

### DIFF
--- a/src/main/resources/secret.properties
+++ b/src/main/resources/secret.properties
@@ -1,1 +1,1 @@
-token=MTAyNTMxMDM3NTk3NTA3MTc3NA.GzOfhV.atqxM4KByz3gSG6D4AvWZXfr_iPBKnan0Wnjy8
+token=


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 為了轉換為 public repo，移除敏感資訊
## Changes made:
- 移除 discord bot token
## Test Scope / Change impact:
-
