### PR TITLE
feat: Add mute audiences and mute revoked commands

### DIFF
--- a/audio-experience/.gitignore
+++ b/audio-experience/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/audio-experience/pom.xml
+++ b/audio-experience/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>tw.waterballsa.utopia</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>audio-experience</artifactId>
+    <name>Audio Experience</name>
+    <description>A well-crafted audio experience module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>discord-impl-jda</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -25,7 +25,7 @@ private const val MUTE_REVOKED_COMMAND = "$MUTE_SLASH $REVOKED_SUB_COMMAND"
 private val log = KotlinLogging.logger {}
 private var currentCommandName = ""
 
-fun muteAudiences(wsa: WsaDiscordProperties) = listener {
+fun muteAudiences() = listener {
     /*
     mute audiences: The command allows the user to mute audiences
         Optional -> audience: Allow the audience to unmute
@@ -43,7 +43,7 @@ fun muteAudiences(wsa: WsaDiscordProperties) = listener {
     }
 
     on<SlashCommandInteractionEvent> {
-        val memberChannel: AudioChannelUnion? = member?.voiceState?.channel
+        val memberChannel = member?.voiceState?.channel
         log.info { "[Mute Command]: Command in $channel" }
         log.info { "[Mute Command]: User in $memberChannel" }
 
@@ -51,13 +51,13 @@ fun muteAudiences(wsa: WsaDiscordProperties) = listener {
             return@on
         }
 
-        val voiceChannel: VoiceChannel = channel.asVoiceChannel();
+        val voiceChannel = channel.asVoiceChannel();
 
         when (fullCommandName) {
             MUTE_AUDIENCES_COMMAND -> {
                 currentCommandName = MUTE_AUDIENCES_COMMAND
-                val role: OptionMapping? = getOption(OPTION_ROLE_NAME);
-                val audience: OptionMapping? = getOption(OPTION_AUDIENCE_NAME);
+                val role = getOption(OPTION_ROLE_NAME);
+                val audience = getOption(OPTION_AUDIENCE_NAME);
 
                 voiceChannel.members.forEach {
                     when {
@@ -84,9 +84,9 @@ private fun SlashCommandInteractionEvent.isNotMuteCommand(): Boolean {
 }
 
 private fun SlashCommandInteractionEvent.isNotVoiceChannel(): Boolean {
-    val memberChannel: AudioChannelUnion? = member?.voiceState?.channel
+    val memberChannelId = member?.voiceState?.channel?.id
 
-    val isVoiceChannel: Boolean = (memberChannel != null) && (channel == memberChannel)
+    val isVoiceChannel = (memberChannelId != null) && (channel.id == memberChannelId)
     if (!isVoiceChannel) {
         this.reply("This is not a voice channel.").queue()
     }
@@ -102,9 +102,9 @@ private fun isUnmuteRole(member: Member, role: OptionMapping?): Boolean {
 }
 
 private fun muteMember(member: Member, isMute: Boolean) {
-    val memberName: String? = if (member.nickname != null) member.nickname else member.effectiveName
-    val memberId: String = member.id
-    val muteLabel: String = if (isMute) "Mute" else "Unmute"
+    val memberName = member.nickname ?: member.effectiveName
+    val memberId = member.id
+    val muteLabel = if (isMute) "Mute" else "Unmute"
 
     member.mute(isMute)
         .queue { log.info { "[$currentCommandName]: $muteLabel {\"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"} voice !!" } }

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -1,0 +1,66 @@
+package tw.waterballsa.utopia.audiox
+
+import net.dv8tion.jda.api.entities.Widget.VoiceChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
+import tw.waterballsa.utopia.jda.listener
+
+private const val OPTION_AUDIENCE_NAME = "audience"
+private const val OPTION_ROLE_NAME = "role"
+
+fun muteAudiences(wsa: WsaDiscordProperties) = listener {
+    // hello world <arg1>
+    // <feature-module's name> <feature's name> <arg1> <arg2> ....
+
+    // mute audiences
+    // allow alpha members
+    // allow speakers
+    command {
+        Commands.slash("mute", "Mute")
+            .addSubcommands(
+                SubcommandData("audiences", "Mute Audiences")
+                    .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice")
+                    .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice"),
+                SubcommandData("revoked", "UnMute")
+            )
+    }
+
+    on<SlashCommandInteractionEvent>{
+        // 監聽事件
+        // reactive programming
+
+        // sync: block to complete()
+        // async: execute to queue()
+        if ((fullCommandName != "mute audiences" || fullCommandName != "mute revoked" ) && channel is VoiceChannel){
+            return@on
+        }
+
+        val voiceChannel = channel.asVoiceChannel();
+
+        if (fullCommandName == "mute audiences"){
+            val role = getOption(OPTION_ROLE_NAME);
+            val audience = getOption(OPTION_AUDIENCE_NAME);
+
+            voiceChannel.members.forEach{
+                if (it.id == audience?.asUser?.id){
+                    it.mute(false).queue()
+                }
+                else if (it.roles.contains(role?.asRole)) {
+                    it.mute(false).queue()
+                }
+                else
+                    it.mute(true).queue()
+            }
+            this.reply("Mute audience voice !!").queue()
+        }
+        else if (fullCommandName == "mute revoked"){
+            voiceChannel.members.forEach{ it.mute(false).queue() }
+            this.reply("UnMute voice !!").queue()
+        }
+    }
+}
+
+

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -1,7 +1,10 @@
 package tw.waterballsa.utopia.audiox
 
-import net.dv8tion.jda.api.entities.Widget.VoiceChannel
+import mu.KotlinLogging
+import net.dv8tion.jda.api.entities.GuildVoiceState
+import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
@@ -10,57 +13,113 @@ import tw.waterballsa.utopia.jda.listener
 
 private const val OPTION_AUDIENCE_NAME = "audience"
 private const val OPTION_ROLE_NAME = "role"
+private const val MUTE_SLASH = "mute"
+private const val AUDIENCES_SUBCOMMAND = "audiences"
+private const val MUTE_AUDIENCES_COMMAND = "$MUTE_SLASH $AUDIENCES_SUBCOMMAND"
+private const val REVOKED_SUB_COMMAND = "revoked"
+private const val MUTE_REVOKED_COMMAND = "$MUTE_SLASH $REVOKED_SUB_COMMAND"
+
+private val log = KotlinLogging.logger {}
 
 fun muteAudiences(wsa: WsaDiscordProperties) = listener {
-    // hello world <arg1>
-    // <feature-module's name> <feature's name> <arg1> <arg2> ....
-
-    // mute audiences
-    // allow alpha members
-    // allow speakers
+    /*
+    mute audiences: The command allows the user to mute audiences
+        Optional -> audience: Allow the audience to unmute
+        Optional -> role: Allow all members of a role to unmute
+    mute revoked: The command allows the user to revoke mute
+    */
     command {
-        Commands.slash("mute", "Mute")
+        Commands.slash(MUTE_SLASH, "Mute")
             .addSubcommands(
-                SubcommandData("audiences", "Mute Audiences")
-                    .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice")
-                    .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice"),
-                SubcommandData("revoked", "UnMute")
+                SubcommandData(AUDIENCES_SUBCOMMAND, "Mute Audiences")
+                    .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice", false)
+                    .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice", false),
+                SubcommandData(REVOKED_SUB_COMMAND, "UnMute")
             )
     }
 
     on<SlashCommandInteractionEvent>{
-        // 監聽事件
-        // reactive programming
-
-        // sync: block to complete()
-        // async: execute to queue()
-        if ((fullCommandName != "mute audiences" || fullCommandName != "mute revoked" ) && channel is VoiceChannel){
+        if (isNotMuteCommand() && isNotVoiceChannel()){
             return@on
         }
 
         val voiceChannel = channel.asVoiceChannel();
 
-        if (fullCommandName == "mute audiences"){
-            val role = getOption(OPTION_ROLE_NAME);
-            val audience = getOption(OPTION_AUDIENCE_NAME);
+        when (fullCommandName){
+            MUTE_AUDIENCES_COMMAND -> {
+                val role = getOption(OPTION_ROLE_NAME);
+                val audience = getOption(OPTION_AUDIENCE_NAME);
 
-            voiceChannel.members.forEach{
-                if (it.id == audience?.asUser?.id){
-                    it.mute(false).queue()
+                voiceChannel.members.forEach{
+                    val memberName = it.nickname
+                    val memberId = it.id
+                    when {
+                        isUnMuteAudiences(it, audience)-> {
+                            it.mute(false).queue {
+                                displayUnMuteLog(MUTE_AUDIENCES_COMMAND, "{\"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}")
+                            }
+                        }
+                        isUnMuteRole(it, role) -> {
+                            val memberRole = role?.asRole
+                            it.mute(false).queue {
+                                displayUnMuteLog(MUTE_AUDIENCES_COMMAND, "{\"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\", \"memberRole\":\"${memberRole}\"}")
+                            }
+                        }
+                        else -> {
+                            it.mute(true).queue{
+                                displayMuteLog(MUTE_AUDIENCES_COMMAND, "{\"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}")
+                            }
+                        }
+                    }
                 }
-                else if (it.roles.contains(role?.asRole)) {
-                    it.mute(false).queue()
-                }
-                else
-                    it.mute(true).queue()
+                this.reply("Mute audience voice !!").queue()
             }
-            this.reply("Mute audience voice !!").queue()
-        }
-        else if (fullCommandName == "mute revoked"){
-            voiceChannel.members.forEach{ it.mute(false).queue() }
-            this.reply("UnMute voice !!").queue()
+            MUTE_REVOKED_COMMAND -> {
+                voiceChannel.members.forEach{
+                    val memberName = it.nickname
+                    val memberId = it.id
+                    it.mute(false).queue{
+                        displayUnMuteLog(MUTE_REVOKED_COMMAND, "{\"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}")
+                }}
+
+                this.reply("UnMute voice !!").queue()
+            }
         }
     }
 }
 
+
+
+private fun SlashCommandInteractionEvent.isNotMuteCommand(): Boolean{
+    return fullCommandName != MUTE_AUDIENCES_COMMAND || fullCommandName != MUTE_REVOKED_COMMAND
+}
+
+private fun SlashCommandInteractionEvent.isNotVoiceChannel(): Boolean{
+    val memberVoiceState: GuildVoiceState? = member?.voiceState // return if the user is not connected to a voice channel
+    val memberChannel = memberVoiceState?.channel
+
+    log.info { "[Mute Command]: Command in $channel" }
+    log.info { "[Mute Command]: User in $memberChannel" }
+
+    val isVoiceChannel = memberChannel != null && channel == memberChannel
+    if (!isVoiceChannel)
+        this.reply("This is not a voice channel.").queue()
+    return !isVoiceChannel
+}
+
+private fun displayUnMuteLog(commandName: String, info: String){
+    log.info { "[$commandName]: UnMute $info voice !!" }
+}
+
+private fun displayMuteLog(commandName: String, info: String){
+    log.info { "[$commandName]: Mute $info voice !!" }
+}
+
+private fun isUnMuteAudiences(member: Member, audience: OptionMapping?): Boolean{
+    return member.id == audience?.asUser?.id
+}
+
+private fun isUnMuteRole(member: Member, role: OptionMapping?): Boolean {
+    return member.roles.contains(role?.asRole);
+}
 

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -83,12 +83,6 @@ class MuteAudiences() : UtopiaListener() {
             ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Mute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
     }
 
-    private fun SlashCommandInteractionEvent.executeMuteCommand(muteMemberAction: () -> Unit, replyMessage: String) {
-        val voiceChannel = channel.asVoiceChannel()
-        voiceChannel.members.forEach { _ -> muteMemberAction.invoke() }
-        reply(replyMessage).queue()
-    }
-
     private fun SlashCommandInteractionEvent.unMuteMember() {
         val memberName = member?.nickname ?: member?.effectiveName
         val memberId = member?.id
@@ -96,4 +90,11 @@ class MuteAudiences() : UtopiaListener() {
         member?.mute(false)
             ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Unmute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
     }
+
+    private fun SlashCommandInteractionEvent.executeMuteCommand(muteMemberAction: () -> Unit, replyMessage: String) {
+        val voiceChannel = channel.asVoiceChannel()
+        voiceChannel.members.forEach { _ -> muteMemberAction.invoke() }
+        reply(replyMessage).queue()
+    }
+
 }

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -3,9 +3,11 @@ package tw.waterballsa.utopia.audiox
 import mu.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
-import tw.waterballsa.utopia.jda.listener
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.jda.UtopiaListener
 
 private const val OPTION_AUDIENCE_NAME = "audience"
 private const val OPTION_ROLE_NAME = "role"
@@ -17,85 +19,81 @@ private const val MUTE_REVOKED_COMMAND = "$MUTE_SLASH $REVOKED_SUB_COMMAND"
 
 private val log = KotlinLogging.logger {}
 
-fun muteAudiences() = listener {
-    /*
-    mute audiences: The command allows the user to mute audiences
-        Optional -> audience: Allow the audience to unmute
-        Optional -> role: Allow all members of a role to unmute
-    mute revoked: The command allows the user to revoke mute
-    */
-    command {
-        Commands.slash(MUTE_SLASH, "Mute")
-            .addSubcommands(
-                SubcommandData(AUDIENCES_SUBCOMMAND, "Mute Audiences")
-                    .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice", false)
-                    .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice", false),
-                SubcommandData(REVOKED_SUB_COMMAND, "Unmute")
-            )
+@Component
+class MuteAudiences() : UtopiaListener() {
+    override fun commands(): List<CommandData> {
+        return listOf(
+            Commands.slash(MUTE_SLASH, "Mute")
+                .addSubcommands(
+                    SubcommandData(AUDIENCES_SUBCOMMAND, "Mute Audiences")
+                        .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice", false)
+                        .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice", false),
+                    SubcommandData(REVOKED_SUB_COMMAND, "Unmute")
+                )
+        )
     }
 
-    on<SlashCommandInteractionEvent> {
-        val memberChannel = member?.voiceState?.channel
-
-        log.info { "[Mute Command]: {\"commandInChannel\":\"$channel\", \"userInChannel\":\"$memberChannel\"}" }
-        if (isNotMuteCommand() && isNotVoiceChannel()) {
-            return@on
-        }
-
-        when (fullCommandName) {
-            MUTE_AUDIENCES_COMMAND -> {
-                val muteMemberAction: () -> Unit = if (isUnmute()) ::unMuteMember else ::muteMember
-                executeMuteCommand(muteMemberAction, "Mute audience voice !!")
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        with(event) {
+            val memberChannel = member?.voiceState?.channel
+            log.info { "[Mute Command]: {\"commandInChannel\":\"$channel\", \"userInChannel\":\"$memberChannel\"}" }
+            if (isNotMuteCommand() && isNotVoiceChannel()) {
+                return
             }
 
-            MUTE_REVOKED_COMMAND -> executeMuteCommand({ unMuteMember() }, "Unmute voice !!")
+            when (fullCommandName) {
+                MUTE_AUDIENCES_COMMAND -> {
+                    val muteMemberAction = if (isUnmute()) unMuteMember() else muteMember()
+                    executeMuteCommand({ muteMemberAction }, "Mute audience voice !!")
+                }
+
+                MUTE_REVOKED_COMMAND -> executeMuteCommand({ unMuteMember() }, "Unmute voice !!")
+            }
         }
     }
-}
 
-
-private fun SlashCommandInteractionEvent.isNotMuteCommand(): Boolean {
-    return fullCommandName != MUTE_AUDIENCES_COMMAND || fullCommandName != MUTE_REVOKED_COMMAND
-}
-
-private fun SlashCommandInteractionEvent.isNotVoiceChannel(): Boolean {
-    val memberChannelId = member?.voiceState?.channel?.id
-
-    val isVoiceChannel = (memberChannelId != null) && (channel.id == memberChannelId)
-    if (!isVoiceChannel) {
-        this.reply("This is not a voice channel.").queue()
+    private fun SlashCommandInteractionEvent.isNotMuteCommand(): Boolean {
+        return fullCommandName != MUTE_AUDIENCES_COMMAND || fullCommandName != MUTE_REVOKED_COMMAND
     }
-    return !isVoiceChannel
+
+    private fun SlashCommandInteractionEvent.isNotVoiceChannel(): Boolean {
+        val memberChannelId = member?.voiceState?.channel?.id
+
+        val isVoiceChannel = (memberChannelId != null) && (channel.id == memberChannelId)
+        if (!isVoiceChannel) {
+            reply("This is not a voice channel.").queue()
+        }
+        return !isVoiceChannel
+    }
+
+    private fun SlashCommandInteractionEvent.isUnmute(): Boolean {
+        val audience = getOption(OPTION_AUDIENCE_NAME)
+        val role = getOption(OPTION_ROLE_NAME)
+
+        val isUnmuteAudiences = member?.id == audience?.asUser?.id
+        val isUnmuteRole = member?.roles?.contains(role?.asRole) == true
+        return isUnmuteAudiences || isUnmuteRole
+    }
+
+    private fun SlashCommandInteractionEvent.muteMember() {
+        val memberName = member?.nickname ?: member?.effectiveName
+        val memberId = member?.id
+
+        member?.mute(true)
+            ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Mute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
+    }
+
+    private fun SlashCommandInteractionEvent.executeMuteCommand(muteMemberAction: () -> Unit, replyMessage: String) {
+        val voiceChannel = channel.asVoiceChannel()
+        voiceChannel.members.forEach { _ -> muteMemberAction.invoke() }
+        reply(replyMessage).queue()
+    }
+
+    private fun SlashCommandInteractionEvent.unMuteMember() {
+        val memberName = member?.nickname ?: member?.effectiveName
+        val memberId = member?.id
+
+        member?.mute(false)
+            ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Unmute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
+    }
 }
-
-private fun SlashCommandInteractionEvent.isUnmute(): Boolean {
-    val audience = getOption(OPTION_AUDIENCE_NAME)
-    val role = getOption(OPTION_ROLE_NAME)
-
-    val isUnmuteAudiences = member?.id == audience?.asUser?.id
-    val isUnmuteRole = member?.roles?.contains(role?.asRole) == true
-    return isUnmuteAudiences || isUnmuteRole
-}
-
-private fun SlashCommandInteractionEvent.muteMember() {
-    val memberName = member?.nickname ?: member?.effectiveName
-    val memberId = member?.id
-
-    member?.mute(true)
-        ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Mute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
-}
-
-private fun SlashCommandInteractionEvent.executeMuteCommand(muteMemberAction: () -> Unit, replyMessage: String) {
-    val voiceChannel = channel.asVoiceChannel()
-    voiceChannel.members.forEach { _ -> muteMemberAction.invoke() }
-    this.reply(replyMessage).queue()
-}
-
-private fun SlashCommandInteractionEvent.unMuteMember() {
-    val memberName = member?.nickname ?: member?.effectiveName
-    val memberId = member?.id
-
-    member?.mute(false)
-        ?.queue { log.info { "[$fullCommandName]: {\"muteLabel\":\"Unmute\", \"memberName\":\"${memberName}\", \"memberId\":\"${memberId}\"}" } }
-}
-

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -86,7 +86,8 @@ private fun SlashCommandInteractionEvent.muteMember() {
 }
 
 private fun SlashCommandInteractionEvent.executeMuteCommand(muteMemberAction: () -> Unit, replyMessage: String) {
-    muteMemberAction.invoke()
+    val voiceChannel = channel.asVoiceChannel()
+    voiceChannel.members.forEach { _ -> muteMemberAction.invoke() }
     this.reply(replyMessage).queue()
 }
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -64,6 +64,10 @@
             <groupId>tw.waterballsa.utopia</groupId>
             <artifactId>document</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>audio-experience</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>random</module>
         <module>actuator</module>
         <module>document</module>
+        <module>audio-experience</module>
     </modules>
 
     <properties>
@@ -212,6 +213,11 @@
             <dependency>
                 <groupId>tw.waterballsa.utopia</groupId>
                 <artifactId>document</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>tw.waterballsa.utopia</groupId>
+                <artifactId>audio-experience</artifactId>
                 <version>${revision}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
[](url)## Why need this change? / Root cause: 
- 節目開始後，為了防止觀眾的祕密被洩漏，需要先對這個語音頻道的觀眾做靜音
## Changes made:
- Voice channel
## Test Scope / Change impact:
-
![螢幕擷取畫面 2023-04-16 181315](https://user-images.githubusercontent.com/31186669/232294992-53f54fe6-8b57-4bf9-8aa5-693761cebb86.png)

![螢幕擷取畫面 2023-04-16 181703](https://user-images.githubusercontent.com/31186669/232295214-a30d942d-bc54-4815-8691-17541f9c1f25.png)

![螢幕擷取畫面 2023-04-16 181414](https://user-images.githubusercontent.com/31186669/232294855-271fe04f-221d-46c4-88e1-bf3da30601d8.png)
