### PR TITLE
bugfix: filter out non-ping commands

### DIFF
--- a/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
+++ b/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
@@ -23,14 +23,14 @@ class PingPong() : UtopiaListener() {
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         with(event) {
-            if (!isPingCommand(fullCommandName)) {
+            if (!fullCommandName.isPingCommand()) {
                 return
             }
             reply("pong").setEphemeral(true).queue()
         }
     }
 
-    private fun isPingCommand(fullCommandName: String): Boolean {
-        return PING_COMMAND_NAME == fullCommandName
+    private fun String.isPingCommand(): Boolean {
+        return PING_COMMAND_NAME == this
     }
 }

--- a/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
+++ b/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
@@ -9,17 +9,28 @@ import tw.waterballsa.utopia.jda.UtopiaListener
 /**
  * @author timm
  */
+
+private const val PING_COMMAND_NAME = "ping"
+
 @Component
 class PingPong() : UtopiaListener() {
+
     override fun commands(): List<CommandData> {
         return listOf(
-            Commands.slash("ping", "sends pong")
+            Commands.slash(PING_COMMAND_NAME, "sends pong")
         )
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         with(event) {
+            if (!isPingCommand(fullCommandName)) {
+                return
+            }
             reply("pong").setEphemeral(true).queue()
         }
+    }
+
+    private fun isPingCommand(fullCommandName: String): Boolean {
+        return PING_COMMAND_NAME == fullCommandName
     }
 }

--- a/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
+++ b/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
@@ -23,14 +23,14 @@ class PingPong() : UtopiaListener() {
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         with(event) {
-            if (!fullCommandName.isPingCommand()) {
+            if (!isPingCommand()) {
                 return
             }
             reply("pong").setEphemeral(true).queue()
         }
     }
 
-    private fun String.isPingCommand(): Boolean {
-        return PING_COMMAND_NAME == this
+    private fun SlashCommandInteractionEvent.isPingCommand(): Boolean {
+        return PING_COMMAND_NAME == this.fullCommandName
     }
 }


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 全部的 slash command 都會讓 `PingPong` 動作，預期只有 `/ping` 指令才
## Changes made:
- `PingPong` slash command listener 過濾非 `/ping` 指令
## Test Scope / Change impact:
- 非 `/ping` 指令不會觸發 `PingPong` 動作
