### PR TITLE
add log for JDA failed launch troubleshooting

### DIFF
--- a/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
+++ b/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
@@ -54,6 +54,8 @@ private object JdaInstance {
     val compositeListener = CompositeListener()
     val instance: JDA by lazy {
         val env = getEnv("BOT_TOKEN").trim()
+        // TODO The log should be removed after the issue of the failed launch is solved.
+        log.info { "[Discord bot token] {\"token\"=\"$env\"}" }
         val builder = JDABuilder.createDefault(env)
                 .enableIntents(
                         GatewayIntent.GUILD_MEMBERS,


### PR DESCRIPTION
## Why need this change? / Root cause: 
- deploy 後遇到 `net.dv8tion.jda.api.exceptions.InvalidTokenException: The provided token is invalid!` 但實際上 Github envrionamen bot token 應該是正確的，需要看看發生了什麼問題
## Changes made:
- 在 `jda.kt` 增加 log.info
## Test Scope / Change impact:
- 啟動後會印出 BOT_TOKEN value
