### PR TITLE
Fix announcementTime by using the Asia/Taipei time zone

### DIFF
--- a/knowledge-king/src/main/kotlin/tw/waterballsa/utopia/knowledgeking/Listeners.kt
+++ b/knowledge-king/src/main/kotlin/tw/waterballsa/utopia/knowledgeking/Listeners.kt
@@ -31,7 +31,7 @@ class KnowledgeKingListener(
 
     // Specifies the duration of time given to each contestant to prepare before the start of the game
     // 10.minutes.inWholeMilliseconds
-    private val announcementTime = Calendar.getInstance().apply {
+    private val announcementTime = Calendar.getInstance(TimeZone.getTimeZone("Asia/Taipei")).apply {
         set(Calendar.HOUR_OF_DAY, 22)
         set(Calendar.MINUTE, 20)
         set(Calendar.SECOND, 0)


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 現在執行時間為 GMT+0 時區，更正為 Asia/Taipei
## Changes made:
-
## Test Scope / Change impact:
-
