### PR TITLE
dev: Revert "add log for JDA failed launch troubleshooting (#89)"

### DIFF
--- a/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
+++ b/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
@@ -54,8 +54,6 @@ private object JdaInstance {
     val compositeListener = CompositeListener()
     val instance: JDA by lazy {
         val env = getEnv("BOT_TOKEN").trim()
-        // TODO The log should be removed after the issue of the failed launch is solved.
-        log.info { "[Discord bot token] {\"token\"=\"$env\"}" }
         val builder = JDABuilder.createDefault(env)
                 .enableIntents(
                         GatewayIntent.GUILD_MEMBERS,


### PR DESCRIPTION
## Why need this change? / Root cause: 
- This reverts commit #89 
- 問題已經排除，不需要印出 `BOT_TOKEN` 
## Changes made:
- 移除 `jda.kt` 中印出 `BOT_TOKEN` 的 log
## Test Scope / Change impact:
- 啟動後不會再看到 BOT_TOKEN 出現在 console 上
