### PR TITLE
/poll command: 發起投票，且一定時間後結束投票並展示投票結果

### DIFF
--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -24,13 +24,13 @@ private val log = KotlinLogging.logger {}
 class MuteAudiences() : UtopiaListener() {
     override fun commands(): List<CommandData> {
         return listOf(
-            Commands.slash(MUTE_SLASH, "Mute")
-                .addSubcommands(
-                    SubcommandData(AUDIENCES_SUBCOMMAND, "Mute Audiences")
-                        .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice", false)
-                        .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice", false),
-                    SubcommandData(REVOKED_SUB_COMMAND, "Unmute")
-                )
+                Commands.slash(MUTE_SLASH, "Mute")
+                        .addSubcommands(
+                                SubcommandData(AUDIENCES_SUBCOMMAND, "Mute Audiences")
+                                        .addOption(OptionType.USER, OPTION_AUDIENCE_NAME, "Allow who to voice", false)
+                                        .addOption(OptionType.ROLE, OPTION_ROLE_NAME, "Allow role to voice", false),
+                                SubcommandData(REVOKED_SUB_COMMAND, "Unmute")
+                        )
         )
     }
 

--- a/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/extensions/GenericCommandInteractionEventExtension.kt
+++ b/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/extensions/GenericCommandInteractionEventExtension.kt
@@ -15,6 +15,12 @@ fun GenericCommandInteractionEvent.getOptionAsPositiveInt(name: String): Int? {
     }
 }
 
+fun GenericCommandInteractionEvent.getOptionAsLongInRange(name: String, range: LongRange): Long? {
+    return getOptionAsLongWithValidation(name, "a long that within ${range.first} ~ ${range.last}") {
+        range.contains(it)
+    }
+}
+
 fun GenericCommandInteractionEvent.getOptionAsIntInRange(name: String, range: IntRange): Int? {
     return getOptionAsIntWithValidation(name, "a integer that within ${range.first} ~ ${range.last}") {
         range.contains(it)
@@ -31,6 +37,12 @@ fun GenericCommandInteractionEvent.getOptionAsStringWithValidation(name: String,
                                                                    optionTypeName: String,
                                                                    validation: (String) -> Boolean): String? {
     return getOptionWithValidation(name, optionTypeName, validation) { it?.asString }
+}
+
+fun GenericCommandInteractionEvent.getOptionAsLongWithValidation(name: String,
+                                                                 optionTypeName: String,
+                                                                 validation: (Long) -> Boolean): Long? {
+    return getOptionWithValidation(name, optionTypeName, validation) { it?.asLong }
 }
 
 fun GenericCommandInteractionEvent.getOptionAsIntWithValidation(name: String,

--- a/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
+++ b/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/jda.kt
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration
 import tw.waterballsa.utopia.jda.JdaInstance.compositeListener
 import java.lang.reflect.Method
 
-val log = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 internal class CompositeListener : EventListener {
     internal val listeners: MutableList<UtopiaListener> = mutableListOf()

--- a/gaas/src/main/kotlin/tw/waterballsa/utopia/gaas/ObserveMember.kt
+++ b/gaas/src/main/kotlin/tw/waterballsa/utopia/gaas/ObserveMember.kt
@@ -2,7 +2,6 @@ package tw.waterballsa.utopia.gaas
 
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent

--- a/gaas/src/main/kotlin/tw/waterballsa/utopia/gaas/ObserveMember.kt
+++ b/gaas/src/main/kotlin/tw/waterballsa/utopia/gaas/ObserveMember.kt
@@ -1,0 +1,109 @@
+package tw.waterballsa.utopia.gaas
+
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.UserSnowflake
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
+import tw.waterballsa.utopia.commons.config.logger
+import tw.waterballsa.utopia.commons.extensions.onStart
+import tw.waterballsa.utopia.commons.extensions.toDate
+import tw.waterballsa.utopia.jda.listener
+import java.time.LocalDate.now
+import java.util.*
+import kotlin.concurrent.timerTask
+import kotlin.time.Duration.Companion.hours
+
+private val timer = Timer()
+private val log = logger
+private val observedMemberRepository = ObservedMemberRepository()
+
+fun observeMember(properties: WsaDiscordProperties) = listener {
+    on<SlashCommandInteractionEvent> {
+        val targetUser = getOptionsByType(OptionType.USER).first().asMember!!
+        val alphaRoleId = properties.wsaAlphaRoleId
+        val commandUser = member!!
+        val gaaSMemberRoleId = properties.wsaGaaSMemberRoleId
+
+        when {
+            interaction.fullCommandName != "gaas observe" -> return@on
+            !commandUser.isAlphaMember(alphaRoleId) -> {
+                replyEphemerally("權限不足")
+                return@on
+            }
+
+            !targetUser.isGaaSMember(gaaSMemberRoleId) -> {
+                replyEphemerally("${targetUser.asMention} 並非 GaaS 成員")
+                return@on
+            }
+        }
+
+        if (observedMemberRepository.exists(targetUser.id)) {
+            replyEphemerally("${targetUser.asMention} 已經在觀察名單")
+            return@on
+        }
+
+        observedMemberRepository.addObservedMember(targetUser.toObservedMemberRecord())
+        replyEphemerally("${targetUser.asMention} 已經成功加入觀察名單")
+    }
+}
+
+
+fun removeMember(properties: WsaDiscordProperties) = listener {
+    on<SlashCommandInteractionEvent> {
+        val targetUser = getOptionsByType(OptionType.USER).first().asMember!!
+        val alphaRoleId = properties.wsaAlphaRoleId
+        val commandUser = member!!
+        val gaaSMemberRoleId = properties.wsaGaaSMemberRoleId
+
+        when {
+            interaction.fullCommandName != "gaas unobserve" -> return@on
+            !commandUser.isAlphaMember(alphaRoleId) -> {
+                replyEphemerally("權限不足")
+                return@on
+            }
+
+            !targetUser.isGaaSMember(gaaSMemberRoleId) -> {
+                replyEphemerally("${targetUser.asMention} 並非 GaaS 成員")
+                return@on
+            }
+        }
+
+        if (observedMemberRepository.exists(targetUser.id)) {
+            observedMemberRepository.removeObservedMember(targetUser.id)
+        }
+        replyEphemerally("${targetUser.asMention} 已經從觀察名單移除")
+    }
+}
+
+fun removeExpiredMembersPeriodically(jda: JDA, properties: WsaDiscordProperties) = listener {
+    val guild = jda.getGuildById(properties.guildId)!!
+    val role = jda.getRoleById(properties.wsaGaaSMemberRoleId)!!
+
+    timer.onStart(
+            removeExpiredMemberRolePeriodically(guild, role),
+            now().atStartOfDay().toDate(),
+            24.hours.inWholeMilliseconds
+    )
+}
+
+private fun removeExpiredMemberRolePeriodically(
+        guild: Guild,
+        role: Role
+) = timerTask {
+    observedMemberRepository.findAll()
+            .filter { it.isCreatedTimeOver30Days() }
+            .takeIf { it.isNotEmpty() }
+            ?.onEach { removeRoleFromRecord(guild, it, role) }
+            ?.map { it.id }
+            ?.let { observedMemberRepository.removeObservedMemberByIds(it) }
+}
+
+private fun removeRoleFromRecord(guild: Guild, record: ObservedMemberRecord, role: Role) {
+    guild.removeRoleFromMember(UserSnowflake.fromId(record.id), role).queue {
+        log.info { "[Observe] {\"Observe\" : \"Remove the expired Member [${record.name}]. \"}" }
+    }
+}

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -76,6 +76,11 @@
             <groupId>tw.waterballsa.utopia</groupId>
             <artifactId>audience-counter</artifactId>
         </dependency>
+
+        <!--        <dependency>-->
+        <!--            <groupId>tw.waterballsa.utopia</groupId>-->
+        <!--            <artifactId>poll</artifactId>-->
+        <!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/poll/pom.xml
+++ b/poll/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>tw.waterballsa.utopia</groupId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>poll</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>discord-impl-jda</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
+++ b/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import org.springframework.stereotype.Component
-import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
 import tw.waterballsa.utopia.commons.extensions.scheduleDelay
 import tw.waterballsa.utopia.jda.UtopiaListener
 import tw.waterballsa.utopia.jda.extensions.getOptionAsLongInRange
@@ -43,13 +42,13 @@ private val timer = Timer()
  * @author johnny@waterballsa.tw
  */
 @Component
-class PollCommandListener(private val wsa: WsaDiscordProperties) : UtopiaListener() {
+class PollCommandListener : UtopiaListener() {
     // embedded session id (message's id) to polling session
     private val sessionIdToSession: ConcurrentHashMap<String, PollingSession> = ConcurrentHashMap()
 
     override fun commands(): List<CommandData> {
         return listOf(
-                Commands.slash("poll", "<TODO>")
+                Commands.slash("poll", "Initiate a polling session and permit Discord members to cast their votes for various options within a specified amount of time.")
                         .addRequiredOption(OptionType.INTEGER, OPTION_TIME, "The duration of the poll session")
                         .addRequiredOption(OptionType.STRING, OPTION_TIMEUNIT, "(Day | Minute | Second)")
                         .addRequiredOption(OptionType.STRING, OPTION_QUESTION, "Question")
@@ -72,7 +71,7 @@ class PollCommandListener(private val wsa: WsaDiscordProperties) : UtopiaListene
                 message.addReaction(Emoji.fromUnicode(EMOJI_UNICODES[i])).complete()
             }
 
-            scheduleTaskToEndThePollingSession(wsa, jda, pollingSession)
+            scheduleTaskToEndThePollingSession(jda, pollingSession)
         }
     }
 
@@ -93,8 +92,6 @@ class PollCommandListener(private val wsa: WsaDiscordProperties) : UtopiaListene
         return PollingSetting(time!!, timeUnit, question, options)
     }
 
-    // TODO:
-    // 一人一票的限制
     override fun onMessageReactionAdd(event: MessageReactionAddEvent) {
         with(event) {
             val session = sessionIdToSession[messageId] ?: return
@@ -115,7 +112,7 @@ class PollCommandListener(private val wsa: WsaDiscordProperties) : UtopiaListene
         }
     }
 
-    private fun scheduleTaskToEndThePollingSession(wsa: WsaDiscordProperties, jda: JDA, pollingSession: PollingSession) {
+    private fun scheduleTaskToEndThePollingSession(jda: JDA, pollingSession: PollingSession) {
         val setting = pollingSession.setting
         timer.scheduleDelay(setting.timeUnit.toMillis(setting.time)) {
             val pollingResult = pollingSession.end()

--- a/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
+++ b/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
@@ -19,6 +19,7 @@ import tw.waterballsa.utopia.jda.UtopiaListener
 import tw.waterballsa.utopia.jda.extensions.getOptionAsLongInRange
 import tw.waterballsa.utopia.jda.extensions.getOptionAsStringWithValidation
 import java.awt.Color
+import java.lang.System.lineSeparator
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -77,7 +78,7 @@ class PollCommandListener : UtopiaListener() {
 
 
     private fun SlashCommandInteractionEvent.parsePollingSettingFromOptions(): PollingSetting? {
-        val time = getOptionAsLongInRange(OPTION_TIME, 0..500L)
+        val time = getOptionAsLongInRange(OPTION_TIME, 0..500L)!!
         val timeUnit = getOptionAsStringWithValidation(OPTION_TIMEUNIT, "should be one of (Days | Minutes | Seconds)") {
             TimeUnit.values().any { unit -> unit.name == it.uppercase() }
         }?.let { TimeUnit.valueOf(it.uppercase()) } ?: return null
@@ -89,7 +90,7 @@ class PollCommandListener : UtopiaListener() {
             return null
         }
 
-        return PollingSetting(time!!, timeUnit, question, options)
+        return PollingSetting(time, timeUnit, question, options)
     }
 
     override fun onMessageReactionAdd(event: MessageReactionAddEvent) {
@@ -130,7 +131,7 @@ class PollCommandListener : UtopiaListener() {
 data class PollingSetting(val time: Long, val timeUnit: TimeUnit, val question: String, val options: List<String>) {
     private val optionsMessageBody = options.mapIndexed { i, option ->
         "${EMOJI_UNICODES[i]} $option"
-    }.joinToString("\n")
+    }.joinToString(lineSeparator())
 
 
     fun toMessageEmbeds(): Collection<MessageEmbed> =
@@ -195,7 +196,7 @@ class PollingResult(private val voterIdToVotedOptionIndices: Map<String, Mutable
                     .groupingBy { it }
                     .eachCount()
                     .map { (index, count) -> "${setting.getOption(index)}: $count votes." }
-                    .joinToString("\n")
+                    .joinToString(lineSeparator())
         }
 }
 

--- a/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
+++ b/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
@@ -1,0 +1,132 @@
+package tw.waterballsa.utopia.poll
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.emoji.Emoji
+import net.dv8tion.jda.api.entities.emoji.EmojiUnion
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
+import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.jda.extensions.getOptionAsIntInRange
+import tw.waterballsa.utopia.jda.extensions.getOptionAsStringWithValidation
+import java.awt.Color
+import java.util.concurrent.TimeUnit
+
+private const val OPTION_TIME = "time"
+
+private const val OPTION_TIMEUNIT = "time-unit"
+
+private const val OPTION_QUESTION = "question"
+
+private const val OPTION_OPTIONS = "options"
+
+private val EMOJI_UNICODES: Array<String> = arrayOf("0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣")
+
+/**
+ * /poll time=1 timeUnit=minutes question="Which operating system do you prefer?" options="Windows,MacOS,Linux,Other"
+ * @author johnny@waterballsa.tw
+ */
+@Component
+class PollCommandListener(private val wsa: WsaDiscordProperties) : UtopiaListener() {
+    // embedded message's id to polling session
+    private val messageIdToSession: MutableMap<String, PollingSession> = mutableMapOf()
+
+    override fun commands(): List<CommandData> {
+        return listOf(
+                Commands.slash("poll", "<TODO>")
+                        .addRequiredOption(OptionType.INTEGER, OPTION_TIME, "The duration of the poll session")
+                        .addRequiredOption(OptionType.STRING, OPTION_TIMEUNIT, "(Day | Minute | Second)")
+                        .addRequiredOption(OptionType.STRING, OPTION_QUESTION, "Question")
+                        .addRequiredOption(OptionType.STRING, OPTION_OPTIONS, "Options (split by comma)")
+        )
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        with(event) {
+            if (!fullCommandName.startsWith("poll")) {
+                return
+            }
+            val setting = getPollingSetting()
+
+            val message = channel.sendMessageEmbeds(setting.toMessageEmbeds()).complete()
+            val session = PollingSession(id = message.id, setting = setting)
+            messageIdToSession[message.id] = session
+            options.forEachIndexed { i, _ ->
+                message.addReaction(Emoji.fromUnicode(EMOJI_UNICODES[i])).complete()
+            }
+        }
+    }
+
+
+    private fun SlashCommandInteractionEvent.getPollingSetting(): PollingSetting {
+        val time = getOptionAsIntInRange(OPTION_TIME, 0..500)
+        val timeUnit = getOptionAsStringWithValidation(OPTION_TIMEUNIT, "should be one of (Day | Minute | Second)") {
+            TimeUnit.values().any { unit -> unit.name == it.uppercase() }
+        }.let { TimeUnit.valueOf(it!!.uppercase()) }
+
+        val question = getOption(OPTION_QUESTION)?.asString
+        val options = getOption(OPTION_OPTIONS)?.asString?.split(Regex("\\s*,\\s*"))
+
+        return PollingSetting(time!!, timeUnit, question!!, options!!)
+    }
+
+    override fun onMessageReactionAdd(event: MessageReactionAddEvent) {
+        with(event) {
+            val session = messageIdToSession[messageId] ?: return
+            if (userId == jda.selfUser.id) {
+                return
+            }
+            session.vote(Vote(userId, emoji))
+        }
+    }
+}
+
+data class PollingSetting(val time: Int, val timeUnit: TimeUnit, val question: String, val options: List<String>) {
+    private val optionsMessageBody = options.mapIndexed { i, option ->
+        "${EMOJI_UNICODES[i]} $option"
+    }.joinToString("\n")
+
+
+    fun toMessageEmbeds(): Collection<MessageEmbed> =
+            listOf(
+                    EmbedBuilder()
+                            .setTitle("Polling")
+                            .setDescription(question)
+                            .setColor(Color.GREEN)
+                            .build(),
+                    EmbedBuilder()
+                            .setTitle("Options")
+                            .setDescription(optionsMessageBody)
+                            .setColor(Color.RED)
+                            .build(),
+                    EmbedBuilder()
+                            .setTitle("Settings")
+                            .setDescription("Session ends in $time $timeUnit.")
+                            .setColor(Color.BLUE)
+                            .build(),
+            )
+}
+
+data class Vote(val userId: String, val emoji: EmojiUnion)
+
+class PollingSession(
+        val id: String, private val setting: PollingSetting) {
+    private val voterIdToVotedOptionIndices = hashMapOf<String, MutableList<Int>>()
+    fun vote(vote: Vote) {
+        val emojiIndex = EMOJI_UNICODES.indexOf(vote.emoji.name)
+        if (emojiIndex < 0) {
+            return
+        }
+        voterIdToVotedOptionIndices.computeIfAbsent(vote.userId) { mutableListOf() }
+                .add(emojiIndex)
+    }
+}
+
+private fun SlashCommandData.addRequiredOption(type: OptionType, name: String, description: String) =
+        addOption(type, name, description, true)

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>document</module>
         <module>audio-experience</module>
         <module>utopia-gamification-quest</module>
+        <module>poll</module>
     </modules>
 
     <properties>
@@ -231,6 +232,11 @@
             <dependency>
                 <groupId>tw.waterballsa.utopia</groupId>
                 <artifactId>audio-experience</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>tw.waterballsa.utopia</groupId>
+                <artifactId>poll</artifactId>
                 <version>${revision}</version>
             </dependency>
         </dependencies>

--- a/wsa-bot-commands.md
+++ b/wsa-bot-commands.md
@@ -5,20 +5,35 @@
 |:--------:| --------- | --------------------------- |
 |   1a2b   |           | Start a new guess num game. |
 
-## audio
+## gaas
+|        Commands        | Arguments                                                                                          | Description                                          |
+|:----------------------:| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| gaas stats-avg-and-max | event-date-year(INTEGER): Year<br>event-date-month(INTEGER): Month<br>event-date-day(INTEGER): Day | Get Avg And Max Participants Number at Specific Date |
+|      gaas observe      | gaas-member(USER): GaaS Member                                                                     | Add a specific member to the watchlist               |
+|    gaas unobserved     | gaas-member(USER): GaaS Member                                                                     | Remove a specific member from the watchlist          |
 
+## russian-roulette
+|     Commands     | Arguments | Description  |
+|:----------------:| --------- | ------------ |
+| russian-roulette |           | GaaS Command |
+
+## audio
 |    Commands    | Arguments                                                                                                                                            | Description            |
 |:--------------:| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
 | audio breakout | room-size(INTEGER): Number of members per room.<br>countdown(INTEGER): Countdown time in seconds.<br>room-name(STRING): The name prefix of per room. | Create breakout rooms. |
 
 ## ping
-
 | Commands | Arguments | Description |
 |:--------:| --------- | ----------- |
 |   ping   |           | sends pong  |
 
-## utopia
+## mute
+|    Commands    | Arguments                                                             | Description    |
+|:--------------:| --------------------------------------------------------------------- | -------------- |
+| mute audiences | audience(USER): Allow who to voice<br>role(ROLE): Allow role to voice | Mute Audiences |
+|  mute revoked  |                                                                       | Unmute         |
 
-| Commands | Arguments | Description    |
-|:--------:| --------- | -------------- |
-|  utopia  |           | utopia command |
+## audience
+|     Commands     | Arguments                                            | Description                                    |
+|:----------------:| ---------------------------------------------------- | ---------------------------------------------- |
+| audience counter | time-length(INTEGER): Time is calculated in minutes. | count the resent voice channel audience amount |


### PR DESCRIPTION
## Why need this change? / Root cause: 
- #98 
## Changes made:
- when use poll command, bot will respond the embedded message with polling options 
- work in progress (toggle: off)
## Test Scope / Change impact:
- `/poll`

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added `/poll` command to the bot, allowing users to initiate and participate in polling sessions.
- New Feature: Added functionality to observe and remove members from a list periodically.
- New Feature: Added a new subcommand for muting audiences and fixed a logical error in the `isNotMuteCommand()` function.
- Bug fix: Modified input validation functions to retrieve options from a Discord slash command interaction event with validation.
- Chore: Added a new dependency to the project and included changes to implement the `/poll` command that responds with an embedded message containing polling options.

> "New features abound,
> Polls and observers all around,
> Bugs and errors have been found,
> With this PR, our code is sound."
<!-- end of auto-generated comment: release notes by openai -->