### PR TITLE
chore: add quality gate and discord badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=WSA-Utopia-Discord-Bot&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=WSA-Utopia-Discord-Bot)
+[![Discord invite](https://img.shields.io/badge/chat-on%20Discord-brightgreen.svg?style=social&amp;logo=discord)](https://discord.gg/waterballsa)
+
 # 環境準備
 - Java 17
 - Maven


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 展示專案 Sonar Cloud 品質報告
- 提供 Discord server 邀請連結
## Changes made:
- REAME.md 中新增兩個 badge
  - quality gate
  - discord server invitation  
## Test Scope / Change impact:
![image](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/assets/88727350/5c79b1f9-2d7e-4bb5-b4ba-fd241d40d5d0)
