### PR TITLE
bugfix: add the missing sonar sources config

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,6 +32,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=WSA-Utopia-Discord-Bot

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,10 @@
         <mockito-junit-jupiter.version>5.2.0</mockito-junit-jupiter.version>
         <jtokkit.version>0.4.0</jtokkit.version>
         <markdowngenerator.version>1.3.1.1</markdowngenerator.version>
-        <!--config for sonar cloud code analsist-->
+        <!--config for sonar cloud code analysis-->
         <sonar.organization>waterball-software-academy</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.sources>.</sonar.sources>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 目前只有抓到 xml files，並沒有包含到 `src/main/**` 底下的 Kotlin files 
## Changes made:
- Set `sonar.sources` with `.`
- Config `Source File Inclusions` on SonarCloud UI console
![截圖 2023-05-22 上午12 26 34](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/assets/88727350/cffa1bdb-e2e2-49ad-9f24-1ea122b6bc96)
## Test Scope / Change impact:
SonarCloud 上面 code change 出現 Kotlin files
![image](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/assets/88727350/ed8b0a4f-0325-4879-b812-719fd6a9b80a)

