### PR TITLE
Fix/mute audiences

### DIFF
--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -36,11 +36,11 @@ class MuteAudiences() : UtopiaListener() {
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         with(event) {
-            val memberChannel = member?.voiceState?.channel
-            log.info { "[Mute Command]: {\"commandInChannel\":\"$channel\", \"userInChannel\":\"$memberChannel\"}" }
-            if (isNotMuteCommand() && isNotVoiceChannel()) {
+            if (isNotMuteCommand() || isNotVoiceChannel()) {
                 return
             }
+            val memberChannel = member?.voiceState?.channel
+            log.info { "[Mute Command]: {\"commandInChannel\":\"$channel\", \"userInChannel\":\"$memberChannel\"}" }
 
             when (fullCommandName) {
                 MUTE_AUDIENCES_COMMAND -> {
@@ -54,7 +54,7 @@ class MuteAudiences() : UtopiaListener() {
     }
 
     private fun SlashCommandInteractionEvent.isNotMuteCommand(): Boolean {
-        return fullCommandName != MUTE_AUDIENCES_COMMAND || fullCommandName != MUTE_REVOKED_COMMAND
+        return fullCommandName != MUTE_AUDIENCES_COMMAND && fullCommandName != MUTE_REVOKED_COMMAND
     }
 
     private fun SlashCommandInteractionEvent.isNotVoiceChannel(): Boolean {


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 錯誤lambda 使用方式以及使用非Mute command 執行到mute command action
## Changes made:
- mute command
## Test Scope / Change impact:
- 修正lambda 使用方式以及提早Early return 

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Bug fix: Fixed a logic error in lambda usage and added mute functionality to `MuteAudiences.kt`. Changes made to `muteMember` and `unMuteMember` functions may impact the system.

> "Silence falls upon the crowd,
> With mute command, no voice allowed.
> Logic fixed, errors no more,
> Utopia's audio experience, now better than before."
<!-- end of auto-generated comment: release notes by openai -->