### PR TITLE
[DEV] mount the volume utopia_storage to application

### DIFF
--- a/fly-beta.toml
+++ b/fly-beta.toml
@@ -30,3 +30,7 @@ port = 80
 [[services.ports]]
 handlers = ["tls", "http"]
 port = 443
+
+[mounts]
+source = "utopia_storage"
+destination = "/data"

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -29,3 +29,7 @@ port = 80
 [[services.ports]]
 handlers = ["tls", "http"]
 port = 443
+
+[mounts]
+source = "utopia_storage"
+destination = "/data"


### PR DESCRIPTION
## Why need this change? / Root cause: 
- fly.io 上面 beta, prod applicaation 必須要有個可以持久化資料的空間
## Changes made:
- 在 `wsa-alpha-bot-beta` 和 `wsa-alpha-bot` 底下先建立 1GB 的空間
- 修改 `fly-beta.toml`, `fly-prod.toml` 使其可以使用空間 `/data` 路徑下儲存資料
```
(base) ➜  .git git:(feature/magnet) fly volumes list -a wsa-alpha-bot-beta                                       
ID                      STATE   NAME            SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
vol_3q80vd3jelwrgzy6    created utopia_storage  1GB     ord     ce9f    true                            4 minutes ago   

(base) ➜  .git git:(main) fly volumes list -a wsa-alpha-bot     
ID                      STATE   NAME            SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
vol_ez1nvxkgm0zrmxl7    created utopia_storage  1GB     ord     ce9f    true                            4 minutes ago  
```
## Test Scope / Change impact:
- 未來重新部署之後依然可以讀取之前產生的資料
