### PR TITLE
bugfix: use KotlinLogging instead utopia jda log

### DIFF
--- a/document/src/main/kotlin/tw/waterballsa/utopia/document/LivingDocument.kt
+++ b/document/src/main/kotlin/tw/waterballsa/utopia/document/LivingDocument.kt
@@ -1,12 +1,14 @@
 package tw.waterballsa.utopia.document
 
+import mu.KotlinLogging
 import net.dv8tion.jda.api.entities.Guild
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import tw.waterballsa.utopia.document.extensions.generateCommandTableMarkdown
 import tw.waterballsa.utopia.jda.WSA_GUILD_BEAN_NAME
-import tw.waterballsa.utopia.jda.log
 import java.io.File
 import java.io.IOException
+
+private val log = KotlinLogging.logger {}
 
 fun generateCommandTableMarkdown(context: AnnotationConfigApplicationContext, filePath: String) {
     val document = context.getBean(WSA_GUILD_BEAN_NAME, Guild::class.java).generateCommandTableMarkdown()

--- a/document/src/main/kotlin/tw/waterballsa/utopia/document/domain/CommandDocument.kt
+++ b/document/src/main/kotlin/tw/waterballsa/utopia/document/domain/CommandDocument.kt
@@ -1,11 +1,13 @@
 package tw.waterballsa.utopia.document.domain
 
+import mu.KotlinLogging
 import net.steppschuh.markdowngenerator.table.Table
-import tw.waterballsa.utopia.jda.log
 
 const val HEADER_COMMANDS = "Commands"
 const val ARGUMENTS = "Arguments"
 const val DESCRIPTION = "Description"
+
+private val log = KotlinLogging.logger {}
 
 class CommandDocument(
         private val commandInfos: List<CommandInfo> = emptyList()


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 使用錯誤的 log
## Changes made:
- 改為 KotlinLogging 
## Test Scope / Change impact:
-

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Refactor: Replace usage of `tw.waterballsa.utopia.jda.log` with `mu.KotlinLogging.logger` and add a private logger instance to the `CommandDocument` class.

> "Logs, logs, they're everywhere,
> But now they're cleaner, without a care.
> Thanks to OpenAI's keen eye,
> Our code is better, no need to sigh."
<!-- end of auto-generated comment: release notes by openai -->