### PR TITLE
Scheduled record highest audience.

### DIFF
--- a/audience-counter/pom.xml
+++ b/audience-counter/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>tw.waterballsa.utopia</groupId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>audience-counter</artifactId>
+    <name>audience-counter(觀眾計數器)</name>
+    <description>This module can count the audience in the voice chat.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>discord-impl-jda</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/audience-counter/src/main/kotlin/tw/waterballsa/utopia/audiencecounter/AudienceCounterListener.kt
+++ b/audience-counter/src/main/kotlin/tw/waterballsa/utopia/audiencecounter/AudienceCounterListener.kt
@@ -1,0 +1,80 @@
+package tw.waterballsa.utopia.audiencecounter
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
+import tw.waterballsa.utopia.commons.extensions.onEnd
+import tw.waterballsa.utopia.commons.extensions.onStart
+import tw.waterballsa.utopia.commons.extensions.toDate
+import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.jda.extensions.getOptionAsPositiveInt
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+import kotlin.concurrent.timerTask
+import kotlin.math.max
+import kotlin.time.Duration.Companion.seconds
+
+
+private const val TIME_LENGTH = "time-length"
+private val channelIdToChannelHighestAudience = hashMapOf<String, Int>()
+
+@Component
+class AudienceCounterListener(private val wsa: WsaDiscordProperties) : UtopiaListener() {
+    override fun commands(): List<CommandData> {
+        return listOf(
+            Commands.slash("audience", "audience command")
+                .addSubcommands(
+                    SubcommandData("counter", "count the resent voice channel audience amount")
+                        .addOption(OptionType.INTEGER, TIME_LENGTH, "Time is calculated in minutes.", true)
+                )
+        )
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        with(event) {
+            if (fullCommandName != "audience counter") {
+                return
+            }
+
+            val recordPeriodTime =
+                getOptionAsPositiveInt(TIME_LENGTH)!!.toLong() // period time between startTime and endTime
+            val currentTime = LocalDateTime.now() // now time
+            val startRecordTime = currentTime.truncatedTo(ChronoUnit.MINUTES).toDate() // start time
+            val endRecordTime = currentTime.plusMinutes(recordPeriodTime).toDate() // end time
+
+            reply("counter start!!!").queue {
+                scheduledRecordHighestAudience(startRecordTime, endRecordTime)
+            }
+        }
+    }
+}
+
+private fun SlashCommandInteractionEvent.scheduledRecordHighestAudience(startRecordTime: Date, endRecordTime: Date) {
+    Timer().run {
+        onStart(recordHighestAudience(), startRecordTime, 5.seconds.inWholeMilliseconds)
+        onEnd(sendResultInVoiceChannel(), endRecordTime)
+    }
+}
+
+private fun SlashCommandInteractionEvent.recordHighestAudience() =
+    timerTask {
+        val commandVoiceChannel = channel.asVoiceChannel()
+        val audienceAmount = commandVoiceChannel.members.size
+        val highestAudience = channelIdToChannelHighestAudience[commandVoiceChannel.id] ?: audienceAmount
+        channelIdToChannelHighestAudience[commandVoiceChannel.id] = max(audienceAmount, highestAudience)
+    }
+
+private fun SlashCommandInteractionEvent.sendResultInVoiceChannel() =
+    timerTask {
+        val commandVoiceChannel = channel.asVoiceChannel()
+        val audienceAmount = commandVoiceChannel.members.size
+        val highestAudience = channelIdToChannelHighestAudience[commandVoiceChannel.id] ?: audienceAmount
+        commandVoiceChannel.sendMessage("The highest audience amounts: **$highestAudience**").queue {
+            channelIdToChannelHighestAudience.remove(commandVoiceChannel.id)
+        }
+    }

--- a/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
+++ b/audio-experience/src/main/kotlin/tw/waterballsa/utopia/audiox/MuteAudiences.kt
@@ -36,6 +36,9 @@ class MuteAudiences() : UtopiaListener() {
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         with(event) {
+            if(fullCommandName != MUTE_AUDIENCES_COMMAND && fullCommandName != MUTE_REVOKED_COMMAND){
+                return
+            }
             if (isNotMuteCommand() || isNotVoiceChannel()) {
                 return
             }

--- a/commons/src/main/kotlin/tw/waterballsa/utopia/commons/extensions/TimerExtension.kt
+++ b/commons/src/main/kotlin/tw/waterballsa/utopia/commons/extensions/TimerExtension.kt
@@ -6,6 +6,8 @@ import kotlin.concurrent.timerTask
 import kotlin.time.Duration.Companion.hours
 
 private val log = KotlinLogging.logger {}
+
+
 fun Timer.onStart(task: TimerTask, startTime: Date, period: Long) = schedule(task, startTime, period)
 
 fun Timer.onEnd(task: TimerTask, endTime: Date) {
@@ -15,7 +17,6 @@ fun Timer.onEnd(task: TimerTask, endTime: Date) {
         log.info { "[TimerTaskFinished] {\"message\":\"Timer task has been closed.\"}" }
     }, endTime)
 }
-
 
 fun Timer.dailyScheduling(hourOfDay: Int, minutes: Int, seconds: Int, task: Runnable) {
     dailyScheduling(Calendar.getInstance().apply {

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -68,6 +68,10 @@
             <groupId>tw.waterballsa.utopia</groupId>
             <artifactId>audio-experience</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>audience-counter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>forum-experience</module>
         <module>gaas</module>
         <module>audio-breakout</module>
+        <module>audience-counter</module>
         <module>guess-num-1A2B</module>
         <module>random</module>
         <module>actuator</module>
@@ -199,6 +200,11 @@
             <dependency>
                 <groupId>tw.waterballsa.utopia</groupId>
                 <artifactId>audio-breakout</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>tw.waterballsa.utopia</groupId>
+                <artifactId>audience-counter</artifactId>
                 <version>${revision}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Why need this change? / Root cause: 
- Schedule the recording of the highest number of audience for a voice channel.
## Changes made:
- AudienceCounterListener
## Test Scope / Change impact:
Using the current time as the reference point in minutes, set it as the starting point for statistical analysis. Add the specified number of minutes to the starting point to determine the ending time for the statistical analysis. During this time period, calculate the maximum number of viewers for the voice channel and notify the voice channel accordingly.