### PR TITLE
✨ add tutorial quests flag post quest

### DIFF
--- a/commons/src/main/kotlin/tw/waterballsa/utopia/commons/config/WsaDiscordProperties.kt
+++ b/commons/src/main/kotlin/tw/waterballsa/utopia/commons/config/WsaDiscordProperties.kt
@@ -29,6 +29,8 @@ open class WsaDiscordProperties(properties: Properties) {
     val unlockEntryChannelLink: String
     val selfIntroChannelLink: String
     val discussionAreaChannelLink: String
+    val flagPostChannelId: String
+    val flagPostChannelLink: String
 
     init {
         properties.run {
@@ -49,6 +51,8 @@ open class WsaDiscordProperties(properties: Properties) {
             unlockEntryChannelLink = getProperty("wsa-unlock-entry-channel-link")
             selfIntroChannelLink = getProperty("wsa-self-intro-channel-link")
             discussionAreaChannelLink = getProperty("wsa-discussion-area-channel-link")
+            flagPostChannelId = getProperty("wsa-flag-post-channel-id")
+            flagPostChannelLink = getProperty("wsa-flag-post-channel-link")
             careerAdvancementTopicChannelId = getProperty("career-advancement-topic-channel-id")
             careerAdvancementTopicChannelLink = getProperty("career-advancement-topic-channel-link")
             engineerLifeChannelId = getProperty("engineer-life-channel-id")

--- a/main/src/main/resources/wsa.beta.properties
+++ b/main/src/main/resources/wsa.beta.properties
@@ -18,4 +18,6 @@ self-intro-channel-id=1039196068455399474
 wsa-self-intro-channel-link=https://discord.com/channels/1038654765896310804/1039196068455399474
 wsa-discussion-area-channel-id=1038657903437037590
 wsa-discussion-area-channel-link=https://discord.com/channels/1038654765896310804/1038657903437037590
+wsa-flag-post-channel-id=1043565056765472798
+wsa-flag-post-channel-link=https://discord.com/channels/1038654765896310804/1043565056765472798
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <junit.version>5.9.2</junit.version>
         <logback-classic-version>1.4.6</logback-classic-version>
         <kotlin-logging-jvm-version>3.0.5</kotlin-logging-jvm-version>
-        <JDA.version>5.0.0-beta.1</JDA.version>
+        <JDA.version>5.0.0-beta.11</JDA.version>
         <kotlin-reflect.version>1.8.10</kotlin-reflect.version>
         <reflections.version>0.10.2</reflections.version>
         <assertj-core.version>3.24.2</assertj-core.version>

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/MessageReactionAction.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/MessageReactionAction.kt
@@ -2,6 +2,7 @@ package tw.waterballsa.utopia.utopiagamificationquest.domain.actions
 
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Action
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
+import kotlin.reflect.safeCast
 
 class MessageReactionAction(
         player: Player,
@@ -18,10 +19,7 @@ class MessageReactionCriteria(
         private val unlockEmoji: String
 ) : Action.Criteria() {
 
-    override fun meet(action: Action): Boolean {
-        return when (action) {
-            is MessageReactionAction -> action.messageId == unlockMessageId && action.emoji == unlockEmoji
-            else -> false
-        }
-    }
+    override fun meet(action: Action) = MessageReactionAction::class.safeCast(action)?.let { meetCriteria(it) } ?: false
+
+    private fun meetCriteria(action: MessageReactionAction): Boolean = action.messageId == unlockMessageId && action.emoji == unlockEmoji
 }

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/MessageSentAction.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/MessageSentAction.kt
@@ -2,6 +2,7 @@ package tw.waterballsa.utopia.utopiagamificationquest.domain.actions
 
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Action
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
+import kotlin.reflect.safeCast
 
 class MessageSentAction(
         player: Player,
@@ -26,16 +27,12 @@ class MessageSentCriteria(
         private var completedTimes: Int = 0
 ) : Action.Criteria() {
 
-    override fun meet(action: Action): Boolean {
-        return when (action) {
-            is MessageSentAction -> action.channelId.contains(channelId) &&
-                    action.numberOfVoiceChannelMembers >= numberOfVoiceChannelMembers &&
-                    action.hasReplied == hasReplied &&
-                    action.hasImage == hasImage &&
-                    action.context matches regex &&
-                    ++completedTimes >= goalCount
+    override fun meet(action: Action) = MessageSentAction::class.safeCast(action)?.let { meetCriteria(it) } ?: false
 
-            else -> false
-        }
-    }
+    private fun meetCriteria(action: MessageSentAction): Boolean = action.channelId == channelId
+            && action.numberOfVoiceChannelMembers >= numberOfVoiceChannelMembers
+            && action.hasReplied == hasReplied
+            && action.hasImage == hasImage
+            && action.context matches regex
+            && ++completedTimes >= goalCount
 }

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/PostAction.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/PostAction.kt
@@ -1,0 +1,23 @@
+package tw.waterballsa.utopia.utopiagamificationquest.domain.actions
+
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Action
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
+import kotlin.reflect.safeCast
+
+
+class PostAction(player: Player, val channelId: String) : Action(player) {
+
+    override fun match(criteria: Criteria): Boolean = criteria is PostCriteria
+
+}
+
+class PostCriteria(
+        private val channelId: String,
+        private val postTimes: Int = 1,
+        private var executeTimes: Int = 0,
+) : Action.Criteria() {
+
+    override fun meet(action: Action) = PostAction::class.safeCast(action)?.let { meetCriteria(it) } ?: false
+
+    private fun meetCriteria(action: PostAction): Boolean = action.channelId == channelId && ++executeTimes >= postTimes
+}

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/quests/TutorialQuests.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/quests/TutorialQuests.kt
@@ -1,8 +1,10 @@
 package tw.waterballsa.utopia.utopiagamificationquest.domain.quests
 
-import tw.waterballsa.utopia.utopiagamificationquest.domain.*
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Quest
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Reward
 import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.MessageReactionCriteria
 import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.MessageSentCriteria
+import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.PostCriteria
 
 private const val unlockEmoji = "🔑"
 
@@ -69,11 +71,27 @@ val Quests.firstMessageActionQuest: Quest
             """.trimIndent()
 
         reward = Reward(
-                "已完成閒聊區第一次留言!!",
+                "已完成閒聊區第一次留言！",
                 100u,
         )
 
         criteria = MessageSentCriteria(wsa.discussionAreaChannelId, 1)
+
+        nextQuest = flagPostQuest
+    }
+val Quests.flagPostQuest: Quest
+    get() = quest {
+        title = "全民插旗子"
+        description =
+            """
+            ${wsa.flagPostChannelLink}
+            在全民插旗子頻道發佈一則貼文
+            """.trimIndent()
+        reward = Reward(
+            "已完成插旗子任務！",
+            100u
+        )
+        criteria = PostCriteria(wsa.flagPostChannelId, 1)
 
         nextQuest = SendContainsImageMessageInEngineerLifeChannelQuest
     }
@@ -88,7 +106,7 @@ val Quests.SendContainsImageMessageInEngineerLifeChannelQuest: Quest
             """.trimIndent()
 
         reward = Reward(
-                "已發布照片!!",
+                "已發布照片！",
                 100u,
         )
 
@@ -103,11 +121,11 @@ val Quests.ReplyToAnyoneInCareerAdvancementTopicChannelQuest: Quest
         description =
                 """
             ${wsa.careerAdvancementTopicChannelLink}
-            到職涯公略區回復其他人的訊息八
+            到職涯攻略區回覆其他人的訊息吧
             """.trimIndent()
 
         reward = Reward(
-                "已回復訊息!!",
+                "已回覆訊息！",
                 100u,
         )
 
@@ -127,7 +145,7 @@ val Quests.SendMessageInVoiceChannelQuest: Quest
             """.trimIndent()
 
         reward = Reward(
-                "已發表一則訊息!!",
+                "已發表一則訊息！",
                 100u,
         )
 

--- a/wsa-bot-commands.md
+++ b/wsa-bot-commands.md
@@ -1,17 +1,5 @@
 # Commands Document
 
-## 1a2b
-| Commands | Arguments | Description                 |
-|:--------:| --------- | --------------------------- |
-|   1a2b   |           | Start a new guess num game. |
-
-## gaas
-|        Commands        | Arguments                                                                                          | Description                                          |
-|:----------------------:| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| gaas stats-avg-and-max | event-date-year(INTEGER): Year<br>event-date-month(INTEGER): Month<br>event-date-day(INTEGER): Day | Get Avg And Max Participants Number at Specific Date |
-|      gaas observe      | gaas-member(USER): GaaS Member                                                                     | Add a specific member to the watchlist               |
-|    gaas unobserved     | gaas-member(USER): GaaS Member                                                                     | Remove a specific member from the watchlist          |
-
 ## audio
 |    Commands    | Arguments                                                                                                                                            | Description            |
 |:--------------:| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
@@ -21,6 +9,33 @@
 | Commands | Arguments | Description |
 |:--------:| --------- | ----------- |
 |   ping   |           | sends pong  |
+
+## random
+|    Commands    | Arguments                                                                                                  | Description |
+|:--------------:| ---------------------------------------------------------------------------------------------------------- | ----------- |
+| random lottery | number(INTEGER): Number of choose members per room.<br>role(ROLE): Only select specific role in this round | Lottery     |
+
+## 1a2b
+| Commands | Arguments | Description                 |
+|:--------:| --------- | --------------------------- |
+|   1a2b   |           | Start a new guess num game. |
+
+## rock-paper-scissors
+|      Commands       | Arguments | Description                           |
+|:-------------------:| --------- | ------------------------------------- |
+| rock-paper-scissors |           | start a new rock paper scissors game! |
+
+## gaas
+|        Commands        | Arguments                                                                                          | Description                                          |
+|:----------------------:| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| gaas stats-avg-and-max | event-date-year(INTEGER): Year<br>event-date-month(INTEGER): Month<br>event-date-day(INTEGER): Day | Get Avg And Max Participants Number at Specific Date |
+|      gaas observe      | gaas-member(USER): GaaS Member                                                                     | Add a specific member to the watchlist               |
+|    gaas unobserved     | gaas-member(USER): GaaS Member                                                                     | Remove a specific member from the watchlist          |
+
+## utopia
+| Commands | Arguments | Description    |
+|:--------:| --------- | -------------- |
+|  utopia  |           | utopia command |
 
 ## mute
 |    Commands    | Arguments                                                             | Description    |
@@ -32,18 +47,3 @@
 |     Commands     | Arguments                                            | Description                                    |
 |:----------------:| ---------------------------------------------------- | ---------------------------------------------- |
 | audience counter | time-length(INTEGER): Time is calculated in minutes. | count the resent voice channel audience amount |
-
-## random
-|    Commands    | Arguments                                                                                                  | Description |
-|:--------------:| ---------------------------------------------------------------------------------------------------------- | ----------- |
-| random lottery | number(INTEGER): Number of choose members per room.<br>role(ROLE): Only select specific role in this round | Lottery     |
-
-## rock-paper-scissors
-|      Commands       | Arguments | Description                           |
-|:-------------------:| --------- | ------------------------------------- |
-| rock-paper-scissors |           | start a new rock paper scissors game! |
-
-## utopia
-| Commands | Arguments | Description    |
-|:--------:| --------- | -------------- |
-|  utopia  |           | utopia command |


### PR DESCRIPTION
## Why need this change? / Root cause: 
- :sparkles: add tutorial quests flag post quest
## Changes made:
- upgrade JDA version to 5.0.0-beta.11.
- add flag post task.
## Test Scope / Change impact:
-

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Upgrade JDA version and add flag post task and channel ID/link. Refactor package names, modify `meetCriteria` function, and add new classes for `PostAction` and `PostCriteria`. Add a new quest and update existing ones. Update `UtopiaGamificationQuestListener` constructor to accept `WsaDiscordProperties`. Remove and add commands in `wsa-bot-commands.md`.

> Upgraded JDA, added flag post task,
> New quest and updated tasks,
> Refactored packages, modified criteria,
> And added new classes for posts' criteria.
> Celebrate these changes with glee,
> For better code quality we guarantee!
<!-- end of auto-generated comment: release notes by openai -->