### PR TITLE
:bug: fix knowledge king oom bug

### DIFF
--- a/chatgpt-api/src/main/kotlin/tw/waterballsa/utopia/chatgpt/JTokkit.kt
+++ b/chatgpt-api/src/main/kotlin/tw/waterballsa/utopia/chatgpt/JTokkit.kt
@@ -2,18 +2,22 @@ package tw.waterballsa.utopia.chatgpt
 
 import com.knuddels.jtokkit.Encodings
 import com.knuddels.jtokkit.api.Encoding
-import com.knuddels.jtokkit.api.EncodingType
+import com.knuddels.jtokkit.api.ModelType
 
 /**
  * use with OpenAI's GPT-3.5 models.
  */
 class JTokkit {
-    private val registry = Encodings.newDefaultEncodingRegistry()
-    private val encodingType: EncodingType = EncodingType.CL100K_BASE
+    companion object {
+        private val registry = Encodings.newLazyEncodingRegistry()
+        private lateinit var encoding: Encoding
+    }
+
+    init {
+        encoding = registry.getEncodingForModel(ModelType.GPT_3_5_TURBO)
+    }
 
     fun measureNumOfTokens(string: String): Int {
-        val encoding: Encoding = registry.getEncoding(encodingType)
-        val encoded: List<Int> = encoding.encode(string)
-        return encoded.size
+        return encoding.countTokens(string)
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jda-ktx.version>0.10.0-beta.1</jda-ktx.version>
         <mockito-junit-jupiter.version>5.2.0</mockito-junit-jupiter.version>
-        <jtokkit.version>0.5.0</jtokkit.version>
+        <jtokkit.version>0.5.1</jtokkit.version>
         <markdowngenerator.version>1.3.1.1</markdowngenerator.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jda-ktx.version>0.10.0-beta.1</jda-ktx.version>
         <mockito-junit-jupiter.version>5.2.0</mockito-junit-jupiter.version>
-        <jtokkit.version>0.4.0</jtokkit.version>
+        <jtokkit.version>0.5.0</jtokkit.version>
         <markdowngenerator.version>1.3.1.1</markdowngenerator.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     </properties>


### PR DESCRIPTION
## Why need this change? / Root cause: 
- Fix the OOM error in Knowledge King

![knowledge-king-oom-error-log](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/assets/7857349/56c84486-5437-4dea-aab7-498cdfdaf747)

## Changes made:
- Upgrade jtokkit version from 0.4.0 to version 0.5.1 and use the new feature about lazy encoding. Reference: https://github.com/knuddelsgmbh/jtokkit/issues/23

## Test Scope / Change impact:
- tw/waterballsa/utopia/chatgpt/JTokkit.kt

![knowledge-king-before-after-impact](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/assets/7857349/033ed326-cbae-4868-ad0a-5518de5d4ebb)

> **Note**
> The "Before" image is from a nice spec VM, just for intended to obtain memory usage information

