### PR TITLE
feat: impl mongo on ping pong

### DIFF
--- a/actuator/pom.xml
+++ b/actuator/pom.xml
@@ -23,6 +23,14 @@
       <groupId>tw.waterballsa.utopia</groupId>
       <artifactId>discord-impl-jda</artifactId>
     </dependency>
+    <dependency>
+      <groupId>tw.waterballsa.utopia</groupId>
+      <artifactId>mongo-gateway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tw.waterballsa.utopia</groupId>
+      <artifactId>mongo-gateway-impl</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
+++ b/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPong.kt
@@ -1,10 +1,14 @@
 package tw.waterballsa.utopia.actuator
 
+import mu.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import org.springframework.stereotype.Component
 import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.mongo.gateway.MongoCollection
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 /**
  * @author timm
@@ -13,7 +17,10 @@ import tw.waterballsa.utopia.jda.UtopiaListener
 private const val PING_COMMAND_NAME = "ping"
 
 @Component
-class PingPong() : UtopiaListener() {
+class PingPong(private val pingPongRepository: MongoCollection<PingPongDocument, String>) : UtopiaListener() {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
 
     override fun commands(): List<CommandData> {
         return listOf(
@@ -26,11 +33,27 @@ class PingPong() : UtopiaListener() {
             if (!isPingCommand()) {
                 return
             }
-            reply("pong").setEphemeral(true).queue()
+            reply("pong").setEphemeral(true).queue() {
+                val userId = member?.id ?: return@queue
+
+                val pingPong = pingPongRepository.findOne(userId)?.let { pingPong ->
+                    pingPong.created = now()
+                    pingPongRepository.save(pingPong)
+                } ?: run {
+                    pingPongRepository.save(PingPongDocument(userId, now()))
+                }
+
+                log.info() { """[pingPong Document] { userId : ${pingPong.userId}, time : ${pingPong.created} }""" }
+            }
         }
     }
 
     private fun SlashCommandInteractionEvent.isPingCommand(): Boolean {
         return PING_COMMAND_NAME == this.fullCommandName
+    }
+
+    private fun now() : Long{
+        val currentDateTime = LocalDateTime.now()
+        return currentDateTime.toInstant(ZoneOffset.UTC).toEpochMilli()
     }
 }

--- a/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPongDocument.kt
+++ b/actuator/src/main/kotlin/tw/waterballsa/utopia/actuator/PingPongDocument.kt
@@ -1,0 +1,10 @@
+package tw.waterballsa.utopia.actuator
+
+import tw.waterballsa.utopia.mongo.gateway.Document
+import tw.waterballsa.utopia.mongo.gateway.Id
+
+@Document
+data class PingPongDocument(
+    @Id val userId: String,
+    var created: Long
+)


### PR DESCRIPTION
## Why need this change? / Root cause: 
- implement collection (repository) feature on ping pong
## Changes made:
-
## Test Scope / Change impact:
-

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added two new dependencies (`mongo-gateway` and `mongo-gateway-impl`) to the project's Maven configuration.
- New Feature: Implemented functionality to store ping-pong data in a MongoDB collection. When the "ping" command is invoked, it saves the user ID and the current timestamp.

> "Ping and pong, together they belong,
> With MongoDB, their journey is strong.
> Dependencies added, features enhanced,
> A game of code, beautifully danced."
<!-- end of auto-generated comment: release notes by openai -->