### PR TITLE
bugfix: temporarily avoid running tests in the docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.8.3-openjdk-17-slim
 
 ADD ./ /
 ## build after dependencies are down so it wont redownload unless the POM changes
-RUN mvn package
+RUN mvn package -Dmaven.test.skip
 
 # Part 2: use the JAR file used in the first part and copy it across ready to RUN
 FROM openjdk:17-jdk-slim


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 因為在 #159 中修復了 kotlin folder 中的測試沒有被執行到的問題，目前的 MongoDB integration 會用到 test containter，考慮到這邊已經是 deploy 階段，理論上已經有通過 CI 的驗證，是處於可以 deploy 的狀態，可以忽略執行測試，直接打包。
## Changes made:
- docker build 階段不執行測試
## Test Scope / Change impact:
- [失敗的 deploy](https://github.com/Waterball-Software-Academy/WSA-Utopia-Discord-Bot/actions/runs/5635862865/job/15267400603#step:4:16700) 可以順利通過。

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Updated Docker build process to skip tests during the build stage by adding `-Dmaven.test.skip` flag to `mvn package` command. This change accelerates the Docker image creation process.

> 🚀 Faster builds, oh what a sight! 🎉
>
> Tests skipped in Docker's flight. 🐳
>
> Maven packages without a fight, 💼
>
> For speedy deployments, day and night! 🌞🌜
<!-- end of auto-generated comment: release notes by openai -->