### PR TITLE
add join activity quest/action/criteria

### DIFF
--- a/utopia-gamification-quest/pom.xml
+++ b/utopia-gamification-quest/pom.xml
@@ -18,5 +18,15 @@
             <groupId>tw.waterballsa.utopia</groupId>
             <artifactId>discord-impl-jda</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>mongo-gateway-impl</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>mongo-gateway</artifactId>
+            <version>${revision}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/JoinActivityListener.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/JoinActivityListener.kt
@@ -1,0 +1,96 @@
+package tw.waterballsa.utopia.utopiagamificationquest
+
+import mu.KotlinLogging
+import net.dv8tion.jda.api.entities.ScheduledEvent
+import net.dv8tion.jda.api.entities.ScheduledEvent.*
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
+import net.dv8tion.jda.api.events.guild.scheduledevent.ScheduledEventCreateEvent
+import net.dv8tion.jda.api.events.guild.scheduledevent.ScheduledEventDeleteEvent
+import net.dv8tion.jda.api.events.guild.scheduledevent.update.ScheduledEventUpdateStatusEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Activity
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Audience
+import tw.waterballsa.utopia.utopiagamificationquest.domain.DateTimeRange
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Mission
+import tw.waterballsa.utopia.utopiagamificationquest.extensions.*
+import tw.waterballsa.utopia.utopiagamificationquest.repositories.ActivityRepository
+import tw.waterballsa.utopia.utopiagamificationquest.service.PlayerFulfillMissionsService
+import java.time.ZoneId
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class EventJoiningListener(
+    private val playerFulfillMissionsService: PlayerFulfillMissionsService,
+    private val activityRepository: ActivityRepository
+) : UtopiaListener() {
+
+    override fun onGuildVoiceUpdate(event: GuildVoiceUpdateEvent) {
+        with(event) {
+            val player = member.user
+
+            channelJoined?.activity?.let {
+                it.join(player.toAudience())
+                activityRepository.save(it)
+            }
+
+            channelLeft?.activity?.let {
+                val action = it.leave(player.id) ?: return
+                playerFulfillMissionsService.execute(action, player.presenter)
+                activityRepository.save(it)
+            }
+        }
+    }
+
+    //TODO 如果 兩個活動 重複了 channel id 該怎麼辦
+    private val AudioChannelUnion.activity
+        get() = activityRepository.findInProgressActivityByChannelId(id)
+
+    private fun User.toAudience(): Audience = Audience(id, name)
+
+    private val User.presenter
+        get() = object : PlayerFulfillMissionsService.Presenter {
+            override fun presentClaimMissionReward(mission: Mission) {
+                claimMissionReward(mission)
+            }
+        }
+
+    override fun onScheduledEventCreate(event: ScheduledEventCreateEvent): Unit =
+        with(event.scheduledEvent) {
+            activityRepository.save(
+                Activity(
+                    id,
+                    creatorIdLong.toString(),
+                    name,
+                    location,
+                    DateTimeRange(startTime.atZoneSameInstant(ZoneId.of("Asia/Taipei")).toLocalDateTime())
+                )
+            )
+            log.info("""[activity created] "activityId" = "$id", "activityName" = "$name"} """)
+        }
+
+
+    override fun onScheduledEventUpdateStatus(event: ScheduledEventUpdateStatusEvent) {
+        with(event.scheduledEvent) {
+            if (status == Status.COMPLETED) {
+                val activity = activityRepository.findByActivityId(id) ?: return
+                activity.end()
+                activityRepository.save(activity)
+                log.info("""[activity end] "activityId" = "$id", "activityName" = "$name"} """)
+            }
+        }
+    }
+
+    override fun onScheduledEventDelete(event: ScheduledEventDeleteEvent) {
+        with(event.scheduledEvent) {
+            val activity = activityRepository.findByActivityId(id) ?: return
+            activity.end()
+            activityRepository.save(activity)
+            log.info("""[activity end] "activityId" = "$id", "activityName" = "$name"} """)
+        }
+    }
+}

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/MessageReactionListener.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/MessageReactionListener.kt
@@ -1,8 +1,10 @@
 package tw.waterballsa.utopia.utopiagamificationquest
 
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent
 import org.springframework.stereotype.Component
 import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Mission
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
 import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.MessageReactionAction
 import tw.waterballsa.utopia.utopiagamificationquest.extensions.claimMissionReward
@@ -18,9 +20,8 @@ class MessageReactionListener(
         with(event) {
             val player = user ?: return
             val action = action ?: return
-            playerFulfillMissionsService.execute(action) { completedMission ->
-                player.claimMissionReward(completedMission)
-            }
+
+            playerFulfillMissionsService.execute(action, player.presenter)
         }
     }
 
@@ -31,5 +32,12 @@ class MessageReactionListener(
                 messageId,
                 emoji.name
             )
+        }
+
+    private val User.presenter
+        get() = object : PlayerFulfillMissionsService.Presenter {
+            override fun presentClaimMissionReward(mission: Mission) {
+                claimMissionReward(mission)
+            }
         }
 }

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/MessageSentListener.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/MessageSentListener.kt
@@ -2,12 +2,14 @@ package tw.waterballsa.utopia.utopiagamificationquest
 
 import dev.minn.jda.ktx.messages.MessageCreateBuilder
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.commands.build.Commands.user
 import org.springframework.stereotype.Component
 import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Mission
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
 import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.MessageSentAction
 import tw.waterballsa.utopia.utopiagamificationquest.extensions.claimMissionReward
@@ -25,9 +27,8 @@ class MessageSentListener(
             }
 
             val player = author
-            playerFulfillMissionsService.execute(action) { completedMission ->
-                player.claimMissionReward(completedMission)
-            }
+
+            playerFulfillMissionsService.execute(action, player.presenter)
         }
     }
 
@@ -40,4 +41,11 @@ class MessageSentListener(
             message.attachments.any { it.isImage },
             (channel as? VoiceChannel)?.members?.size ?: 0
         )
+
+    private val User.presenter
+        get() = object : PlayerFulfillMissionsService.Presenter {
+            override fun presentClaimMissionReward(mission: Mission) {
+                claimMissionReward(mission)
+            }
+        }
 }

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/PostListener.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/PostListener.kt
@@ -1,9 +1,11 @@
 package tw.waterballsa.utopia.utopiagamificationquest
 
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent
 import org.springframework.stereotype.Component
 import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
 import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Mission
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
 import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.PostAction
 import tw.waterballsa.utopia.utopiagamificationquest.extensions.claimMissionReward
@@ -19,10 +21,8 @@ class PostListener(
         with(event) {
             val player = user ?: return
             val action = action ?: return
-            
-            playerFulfillMissionsService.execute(action) { completedMission ->
-                player.claimMissionReward(completedMission)
-            }
+
+            playerFulfillMissionsService.execute(action, player.presenter)
         }
     }
 
@@ -34,5 +34,12 @@ class PostListener(
                 Player(user.id, user.name),
                 it.parentChannel.id
             )
+        }
+
+    private val User.presenter
+        get() = object : PlayerFulfillMissionsService.Presenter {
+            override fun presentClaimMissionReward(mission: Mission) {
+                claimMissionReward(mission)
+            }
         }
 }

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/Activity.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/Activity.kt
@@ -1,0 +1,92 @@
+package tw.waterballsa.utopia.utopiagamificationquest.domain
+
+import mu.KotlinLogging
+import tw.waterballsa.utopia.utopiagamificationquest.domain.actions.JoinActivityAction
+import tw.waterballsa.utopia.utopiagamificationquest.repositories.ActivityDocument
+import tw.waterballsa.utopia.utopiagamificationquest.repositories.AudienceDocument
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalDateTime.now
+
+private val log = KotlinLogging.logger {}
+
+class DateTimeRange(
+    private var startTime: LocalDateTime = now(),
+    private var endTime: LocalDateTime = startTime
+) {
+
+    fun getDuration(): Duration = Duration.between(startTime, endTime)
+
+    fun inTimeRange(): Boolean = startTime == endTime && now().isAfter(startTime.minusMinutes(20))
+
+    fun setEndTimeAsCurrentTime() {
+        endTime = now()
+    }
+
+    fun getStartTime(): String = startTime.toString()
+
+    fun getEndTime(): String = endTime.toString()
+}
+
+class Activity(
+    private val eventId: String,
+    private val hostId: String,
+    private val eventName: String,
+    private val channelId: String,
+    private val dateTimeRange: DateTimeRange = DateTimeRange(),
+    private val audiences: MutableMap<String, Audience> = mutableMapOf()
+) {
+
+    fun join(audience: Audience) {
+        if (!dateTimeRange.inTimeRange()) {
+            return
+        }
+
+        audiences[audience.id] = audience
+
+        log.info(""" [join activity] { "userId" = "${audience.id}", "activityName" = "$eventName"} """)
+    }
+
+    fun leave(audienceId: String): JoinActivityAction? {
+        val audience = audiences[audienceId] ?: return null
+        val stayDuration = audience.leave()
+
+        log.info(""" [leave activity] { "userId" = "$audienceId", "activityName" = $eventName, "stayDuration" = "$stayDuration"} """)
+
+        return JoinActivityAction(
+            audience.toPlayer(),
+            eventName,
+            audiences.size,
+            //TODO 因為方便測試，時間單位為秒，上線前要改成分鐘
+            stayDuration.seconds.toInt()
+        )
+    }
+
+    fun end() = dateTimeRange.setEndTimeAsCurrentTime()
+
+    fun toDocument(): ActivityDocument = ActivityDocument(
+        eventId,
+        hostId,
+        eventName,
+        channelId,
+        dateTimeRange.getStartTime(),
+        dateTimeRange.getEndTime(),
+        audiences.values.map { it.toDocument() }
+    )
+}
+
+class Audience(
+    val id: String,
+    private val audienceName: String,
+    private val joinTime: DateTimeRange = DateTimeRange()
+) {
+    fun leave(): Duration {
+        joinTime.setEndTimeAsCurrentTime()
+        return joinTime.getDuration()
+    }
+
+    fun toPlayer(): Player = Player(id, audienceName)
+
+    fun toDocument(): AudienceDocument =
+        AudienceDocument(id, audienceName, joinTime.getStartTime(), joinTime.getEndTime())
+}

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/JoinActivityAction.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/actions/JoinActivityAction.kt
@@ -1,0 +1,30 @@
+package tw.waterballsa.utopia.utopiagamificationquest.domain.actions
+
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Action
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Player
+
+
+class JoinActivityAction(
+    player: Player,
+    val eventName: String,
+    val maxMemberCount: Int,
+    val stayDuration: Int,
+) : Action(player) {
+    
+    override fun match(criteria: Criteria): Boolean = criteria is JoinActivityCriteria
+}
+
+class JoinActivityCriteria(
+    private val eventName: String,
+    private val maxMemberCount: Int,
+    private val eventDuration: Int
+) : Action.Criteria() {
+    
+    override fun meet(action: Action): Boolean = (action as? JoinActivityAction)?.let { meetCriteria(action) } ?: false
+
+    private fun meetCriteria(action: JoinActivityAction): Boolean {
+        return action.maxMemberCount >= maxMemberCount
+                && action.stayDuration >= eventDuration
+                && action.eventName == eventName
+    }
+}

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/quests/TutorialQuests.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/domain/quests/TutorialQuests.kt
@@ -193,6 +193,23 @@ val Quests.SendMessageInVoiceChannelQuest: Quest
 
         criteria = MessageSentCriteria(ChannelIdRule.ANY_CHANNEL, numberOfVoiceChannelMembersRule = AtLeastRule(2))
 
+        nextQuest = JoinActivityQuest
+    }
+
+val Quests.JoinActivityQuest: Quest
+    get() = quest {
+        title = "任務:參加一場活動"
+        description =
+            """
+            參與名稱為 test 的活動，並停留 10 秒
+            """.trimIndent()
+
+        reward = Reward(
+            "已完成！",
+            100u,
+        )
+
+        criteria = JoinActivityCriteria("test", 1, 10)
         nextQuest = quizQuest
     }
 

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/extensions/UtopiagamificationExtensions.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/extensions/UtopiagamificationExtensions.kt
@@ -4,13 +4,10 @@ import dev.minn.jda.ktx.interactions.components.button
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
 import net.dv8tion.jda.api.interactions.components.buttons.Button
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component
-import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
 import tw.waterballsa.utopia.utopiagamificationquest.domain.Mission
 import tw.waterballsa.utopia.utopiagamificationquest.domain.buttons.QuizButton
 import tw.waterballsa.utopia.utopiagamificationquest.domain.buttons.RewardButton
-import java.util.Properties
+import java.time.LocalDateTime
 
 fun User.claimMissionReward(mission: Mission) {
     openPrivateChannel().complete().publishReward(mission)
@@ -36,3 +33,4 @@ val Mission.quizButton: Button
         QuizButton.LABEL
     )
 
+fun String.toDate(): LocalDateTime = LocalDateTime.parse(this)

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/repositories/ActivityRepository.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/repositories/ActivityRepository.kt
@@ -1,0 +1,70 @@
+package tw.waterballsa.utopia.utopiagamificationquest.repositories
+
+import javassist.LoaderClassPath
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.mongo.gateway.*
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Activity
+import tw.waterballsa.utopia.utopiagamificationquest.domain.Audience
+import tw.waterballsa.utopia.utopiagamificationquest.domain.DateTimeRange
+import tw.waterballsa.utopia.utopiagamificationquest.extensions.toDate
+import java.time.LocalDateTime
+
+interface ActivityRepository {
+    fun findInProgressActivityByChannelId(id: String): Activity?
+    fun findByActivityId(id: String): Activity?
+    fun save(activity: Activity): Activity
+}
+
+@Component
+class MongodbActivityRepository(
+    private val repository: MongoCollection<ActivityDocument, String>
+) : ActivityRepository {
+
+    //TODO 學會怎麼用 Query 之後，改 Query。
+    override fun findInProgressActivityByChannelId(id: String): Activity? =
+        repository.findAll().find { it.channelId == id && it.inProgress() }?.toDomain()
+
+    override fun findByActivityId(id: String): Activity? = repository.findOne(id)?.toDomain()
+
+    override fun save(activity: Activity): Activity {
+        repository.save(activity.toDocument())
+        return activity
+    }
+}
+
+@Document
+class ActivityDocument(
+    @Id val id: String,
+    val hostId: String,
+    val eventName: String,
+    val channelId: String,
+    val startTime: String,
+    val endTime: String,
+    val audiences: List<AudienceDocument>
+) {
+
+    fun toDomain(): Activity = Activity(
+        id,
+        hostId,
+        eventName,
+        channelId,
+        DateTimeRange(startTime.toDate(), endTime.toDate()),
+        audiences.associate { it.toDomain() }.toMutableMap()
+    )
+
+    fun inProgress(): Boolean = DateTimeRange(startTime.toDate(), endTime.toDate()).inTimeRange()
+}
+
+class AudienceDocument(
+    val id: String,
+    val audienceName: String,
+    val startTime: String,
+    val endTime: String,
+) {
+
+    fun toDomain(): Pair<String, Audience> = id to Audience(
+        id,
+        audienceName,
+        DateTimeRange(startTime.toDate(), endTime.toDate())
+    )
+}

--- a/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/service/PlayerFulfillMissionsService.kt
+++ b/utopia-gamification-quest/src/main/kotlin/tw/waterballsa/utopia/utopiagamificationquest/service/PlayerFulfillMissionsService.kt
@@ -10,7 +10,7 @@ class PlayerFulfillMissionsService(
     private val missionRepository: MissionRepository
 ) {
 
-    fun execute(action: Action, presenter: (Mission) -> Unit) {
+    fun execute(action: Action, presenter: Presenter) {
         with(action) {
             val missions = missionRepository.findIncompleteMissionsByPlayerId(player.id)
 
@@ -18,11 +18,15 @@ class PlayerFulfillMissionsService(
         }
     }
 
-    private fun Action.fulfillMissions(missions: List<Mission>, presenter: (Mission) -> Unit) {
+    private fun Action.fulfillMissions(missions: List<Mission>, presenter: Presenter) {
         missions.filter { mission -> mission.match(this) }
             .onEach { mission -> mission.carryOut(this) }
             .filter { mission -> mission.isCompleted() }
             .onEach { mission -> missionRepository.saveMission(mission) }
-            .forEach { mission -> presenter(mission) }
+            .forEach { mission -> presenter.presentClaimMissionReward(mission) }
+    }
+
+    interface Presenter {
+        fun presentClaimMissionReward(mission: Mission)
     }
 }

--- a/wsa-bot-commands.md
+++ b/wsa-bot-commands.md
@@ -23,32 +23,45 @@
 |   ping   |           | sends pong  |
 
 ## mute
+
 |    Commands    | Arguments                                                             | Description    |
 |:--------------:| --------------------------------------------------------------------- | -------------- |
 | mute audiences | audience(USER): Allow who to voice<br>role(ROLE): Allow role to voice | Mute Audiences |
 |  mute revoked  |                                                                       | Unmute         |
 
-## random
-|    Commands    | Arguments                                                                                                  | Description |
-|:--------------:| ---------------------------------------------------------------------------------------------------------- | ----------- |
-| random lottery | number(INTEGER): Number of choose members per room.<br>role(ROLE): Only select specific role in this round | Lottery     |
-
-## rock-paper-scissors
-|      Commands       | Arguments | Description                           |
-|:-------------------:| --------- | ------------------------------------- |
-| rock-paper-scissors |           | start a new rock paper scissors game! |
-
-## utopia
-| Commands | Arguments | Description    |
-|:--------:| --------- | -------------- |
-|  utopia  |           | utopia command |
-
 ## audience
+
 |     Commands     | Arguments                                            | Description                                    |
 |:----------------:| ---------------------------------------------------- | ---------------------------------------------- |
 | audience counter | time-length(INTEGER): Time is calculated in minutes. | count the resent voice channel audience amount |
 
+## random
+
+|    Commands    | Arguments                                                                                                  | Description |
+|:--------------:| ---------------------------------------------------------------------------------------------------------- | ----------- |
+| random lottery | number(INTEGER): Number of choose members per room.<br>role(ROLE): Only select specific role in this round | Lottery     |
+
+## utopia
+
+| Commands | Arguments | Description    |
+|:--------:| --------- | -------------- |
+|  utopia  |           | utopia command |
+
 ## roulette
+
 | Commands | Arguments | Description     |
 |:--------:| --------- | --------------- |
 | roulette |           | Start the game. |
+
+## message
+
+|        Commands        | Arguments                                                                                                               | Description                               |
+|:----------------------:| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+|  message cherry-pick   | start-time(STRING): the start time of the cherry-pick range.<br>end-time(STRING): the end time of the cherry-pick range | to cherry pick message                    |
+| message cherry-pick-to | channel-name(STRING): destination of channel name                                                                       | to cherry pick message to another channel |
+
+## weekly-messages-volume
+
+|        Commands        | Arguments                                                            | Description                                    |
+|:----------------------:| -------------------------------------------------------------------- | ---------------------------------------------- |
+| weekly-messages-volume | channel-name(STRING): The channel to show the weekly messages volume | Show the weekly messages volume of the channel |


### PR DESCRIPTION
## Why need this change? / Root cause: 
- add join activity quest
- add join activity action
- add join activity criteria
## Changes made:
-
## Test Scope / Change impact:
-

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Features:**
- Introduced `EventJoiningListener` to handle events related to joining and leaving activities.
- Added `Activity` and `Audience` classes for managing activity-related data.
- Implemented `JoinActivityAction` and `JoinActivityCriteria` for functionality related to joining activities.
- Created a new quest, "JoinActivityQuest", with its own criteria and rewards.
- Enhanced user interaction with the addition of `User.presenter` extension function.

> 🎉 With listeners keen and actions bright, 🌟
> 
> We've added quests to your delight. 🚀
> 
> Join an activity, claim your prize, 🏆
> 
> In Utopia, every player flies! 🕊️
<!-- end of auto-generated comment: release notes by openai -->