### PR TITLE
Dev/mongodb config add javatime module

### DIFF
--- a/mongo-gateway-impl/pom.xml
+++ b/mongo-gateway-impl/pom.xml
@@ -59,6 +59,11 @@
             <version>${jackson-module-kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson-module-kotlin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/mongo-gateway-impl/src/main/kotlin/tw/waterballsa/utopia/mongo/gatweay/adapter/MongoCollectionAdapter.kt
+++ b/mongo-gateway-impl/src/main/kotlin/tw/waterballsa/utopia/mongo/gatweay/adapter/MongoCollectionAdapter.kt
@@ -1,71 +1,62 @@
 package tw.waterballsa.utopia.mongo.gatweay.adapter
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.bson.Document
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
 import tw.waterballsa.utopia.mongo.gateway.MongoCollection
-
+import tw.waterballsa.utopia.mongo.gateway.Query as MGQuery  // Utopia Mongo Gateway Query
+import tw.waterballsa.utopia.mongo.gatweay.config.MongoDBConfiguration.Companion.MAPPER
 
 private const val MONGO_ID_FIELD_NAME = "_id"
 
 class MongoCollectionAdapter<TDocument, ID>(
-        private val mongoTemplate: MongoTemplate,
-        private val documentInformation: MappingMongoDocumentInformation<TDocument, ID>
+    private val mongoTemplate: MongoTemplate,
+    private val documentInformation: MappingMongoDocumentInformation<TDocument, ID>
 ) : MongoCollection<TDocument, ID> {
 
-    private var objectMapper: ObjectMapper = ObjectMapper()
-            .registerKotlinModule()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    override fun save(document: TDocument): TDocument =
+        mongoTemplate.save(document.toBsonDocument(), documentInformation.collectionName)
+            .toDomainDocument()
 
-    override fun save(document: TDocument): TDocument {
-        return mongoTemplate.save(document.toBsonDocument(), documentInformation.collectionName)
-                .toDomainDocument()
-    }
+    override fun findOne(id: ID): TDocument? =
+        mongoTemplate.findOne(
+            Query.query(Criteria.where(MONGO_ID_FIELD_NAME).`is`(id)),
+            Document::class.java, documentInformation.collectionName
+        )?.toDomainDocument()
 
-    override fun findOne(id: ID): TDocument? {
-        return mongoTemplate.findOne(Query.query(Criteria.where(MONGO_ID_FIELD_NAME).`is`(id)),
-                org.bson.Document::class.java, documentInformation.collectionName)?.toDomainDocument()
-    }
+    override fun findAll(): List<TDocument> =
+        mongoTemplate.findAll(Document::class.java, documentInformation.collectionName)
+            .map { it.toDomainDocument() }
 
-    override fun findAll(): List<TDocument> {
-        return mongoTemplate.findAll(org.bson.Document::class.java, documentInformation.collectionName)
-                .map { it.toDomainDocument() }
-                .toList()
-    }
+    override fun find(query: MGQuery): List<TDocument> =
+        mongoTemplate.getCollection(documentInformation.collectionName)
+            .find(query.getCriteria().getCriteriaObject(), org.bson.Document::class.java)
+            .map { it.toDomainDocument() }
+            .toList()
 
-    override fun find(query: tw.waterballsa.utopia.mongo.gateway.Query): List<TDocument> {
-        return mongoTemplate.getCollection(documentInformation.collectionName)
-                .find(query.getCriteria().getCriteriaObject(), org.bson.Document::class.java)
-                .map { it.toDomainDocument() }
-                .toList()
-    }
+    override fun remove(document: TDocument): Boolean =
+        mongoTemplate.remove(document.toBsonDocument(), documentInformation.collectionName).deletedCount == 1L
 
-    override fun remove(document: TDocument): Boolean {
-        return mongoTemplate.remove(document.toBsonDocument(), documentInformation.collectionName).deletedCount == 1L
-    }
+    override fun removeAll(documents: Collection<TDocument>): Long =
+        with(documents) {
+            val ids = map { it.toBsonDocument()[MONGO_ID_FIELD_NAME] }
+            mongoTemplate.remove(
+                Query.query(Criteria.where(MONGO_ID_FIELD_NAME).`in`(ids)),
+                documentInformation.collectionName
+            ).deletedCount
+        }
 
-    override fun removeAll(documents: Collection<TDocument>): Long {
-        val ids = documents.map { it.toBsonDocument().get(MONGO_ID_FIELD_NAME) }
-                .toList()
-        return mongoTemplate.remove(Query.query(Criteria.where(MONGO_ID_FIELD_NAME).`in`(ids)), documentInformation.collectionName)
-                .deletedCount
-    }
+    private fun TDocument.toBsonDocument(): Document = MAPPER.convertValue(this, Document::class.java)!!
+        .convertIdField(documentInformation.idFieldName, MONGO_ID_FIELD_NAME)
 
-    private fun TDocument.toBsonDocument(): org.bson.Document {
-        return objectMapper.convertValue(this, org.bson.Document::class.java)!!
-                .convertIdField(documentInformation.idFieldName, MONGO_ID_FIELD_NAME)
-    }
-
-    private fun org.bson.Document.toDomainDocument(): TDocument {
+    private fun Document.toDomainDocument(): TDocument {
         convertIdField(MONGO_ID_FIELD_NAME, documentInformation.idFieldName)
-        return objectMapper.readValue(objectMapper.writeValueAsString(this), documentInformation.documentClassType)
+        return MAPPER.convertValue(this, documentInformation.documentClassType)
     }
 
-    private fun org.bson.Document.convertIdField(oldKey: String, newKey: String): org.bson.Document {
+    private fun Document.convertIdField(oldKey: String, newKey: String): Document {
         containsKey(oldKey).let {
             val value = get(oldKey)?.let { if (it is ObjectId) it.toString() else it }
             append(newKey, value)

--- a/mongo-gateway-impl/src/main/kotlin/tw/waterballsa/utopia/mongo/gatweay/config/MongoDBConfiguration.kt
+++ b/mongo-gateway-impl/src/main/kotlin/tw/waterballsa/utopia/mongo/gatweay/config/MongoDBConfiguration.kt
@@ -1,6 +1,11 @@
 package tw.waterballsa.utopia.mongo.gatweay.config
 
 import ch.qos.logback.core.util.OptionHelper
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClients
@@ -32,18 +37,27 @@ import kotlin.reflect.full.findAnnotation
 @Configuration
 open class MongoDBConfiguration {
 
+    companion object {
+        internal val MAPPER = ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+
     @Bean
     open fun mongoTemplate(context: ApplicationContext): MongoTemplate {
         val uri = OptionHelper.getEnv("MONGO_CONNECTION_URI")?.trim()
-                ?: "mongodb://localhost:28017"
+            ?: "mongodb://localhost:28017"
         val settings = MongoClientSettings.builder()
-                .applyConnectionString(ConnectionString(uri))
-                .applyToConnectionPoolSettings { builder ->
-                    builder.maxSize(10)
-                }
-                .build()
+            .applyConnectionString(ConnectionString(uri))
+            .applyToConnectionPoolSettings { builder ->
+                builder.maxSize(10)
+            }
+            .build()
         val wsaDiscordProperties = context.getBean(WsaDiscordProperties::class.java)
-        val factory = SimpleMongoClientDatabaseFactory(MongoClients.create(settings), wsaDiscordProperties.mongoDatabase)
+        val factory =
+            SimpleMongoClientDatabaseFactory(MongoClients.create(settings), wsaDiscordProperties.mongoDatabase)
 
         // remove _class field
         val converter = MappingMongoConverter(DefaultDbRefResolver(factory), MongoMappingContext())
@@ -68,9 +82,9 @@ open class MyBeanFactoryPostProcessor : BeanFactoryPostProcessor, ApplicationCon
 
         for (annotatedClass in annotatedClasses) {
             val idField = annotatedClass.declaredFields
-                    .first { it.annotations.first { annotation -> annotation is Id } != null }!!
+                .first { it.isAnnotationPresent(Id::class.java) }!!
             val resolvableType: ResolvableType =
-                    ResolvableType.forClassWithGenerics(MongoCollection::class.java, annotatedClass, idField.type)
+                ResolvableType.forClassWithGenerics(MongoCollection::class.java, annotatedClass, idField.type)
             val beanDefinition = RootBeanDefinition()
             beanDefinition.setTargetType(resolvableType)
             beanDefinition.autowireMode = AbstractBeanDefinition.AUTOWIRE_BY_TYPE
@@ -78,10 +92,12 @@ open class MyBeanFactoryPostProcessor : BeanFactoryPostProcessor, ApplicationCon
 
             val bf: DefaultListableBeanFactory = beanFactory as DefaultListableBeanFactory
             val collectionName = annotatedClass.kotlin.findAnnotation<Document>()?.collection
-                    ?.ifEmpty { annotatedClass.simpleName }!!
+                ?.ifEmpty { annotatedClass.simpleName }!!
 
-            val mongoCollection = MongoCollectionAdapter(mongoTemplate,
-                    MappingMongoDocumentInformation(collectionName, annotatedClass, idField.type, idField.name))
+            val mongoCollection = MongoCollectionAdapter(
+                mongoTemplate,
+                MappingMongoDocumentInformation(collectionName, annotatedClass, idField.type, idField.name)
+            )
 
             val beanName = "${annotatedClass.simpleName}MongoCollection"
             bf.registerBeanDefinition(beanName, beanDefinition)

--- a/mongo-gateway-impl/src/test/kotlin/tw/waterballsa/utopia/mongo/gatweay/adapter/TestMongoCollectionAdapter.kt
+++ b/mongo-gateway-impl/src/test/kotlin/tw/waterballsa/utopia/mongo/gatweay/adapter/TestMongoCollectionAdapter.kt
@@ -151,19 +151,6 @@ class TestMongoCollectionAdapter : TestMongoBase() {
 
             assertThat(mongoCollectionAdapter.removeAll(documents)).isEqualTo(documents.size.toLong())
         }
-
-    }
-
-    private fun createTestDocument(id: String? = null, age: Int? = null, name: String? = null) {
-        mongoTemplate.insert(
-            Document(
-                mapOf(
-                    Pair("_id", id),
-                    Pair("age", age),
-                    Pair("name", name)
-                )
-            ), TEST_COLLECTION
-        )
     }
 
     private fun TestDocument.saveTestDocument(): TestDocument =


### PR DESCRIPTION
## Why need this change? / Root cause: 
- Mongo Document 儲存的欄位，經常性有時間型態的資料，需要作轉換
- MongoConfiguration 類別裡，註冊 JavaTime Module，讓轉換 Bson 時不會丟出例外，可以正常轉換

## Changes made:
- 可以在 Document 裡，定義 field 為時間型態
```kotlin
Document
data class TestDocument(
    @Id val id: String,
    val createdDate: OffsetDateTime,  // here
) 
```

## Test Scope / Change impact:
-

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for time-related fields in MongoDB documents with the help of `jackson-datatype-jsr310` dependency and JavaTime module.
- Enhanced `MongoCollectionAdapter` to handle a new `createdDate` field of type `OffsetDateTime`.
- Improved operations like save, update, find, and remove in `MongoCollectionAdapter` to accommodate the new time-related field.

**Test:**
- Added test cases to verify the functionality of the newly added time-related field in MongoDB documents.

> 🎉 Time now has a place, in our MongoDB space,
> With JavaTime's grace, we embrace a new pace. 
> Operations race, with newfound trace,
> Tests confirm the case, all in one database! 🚀
<!-- end of auto-generated comment: release notes by openai -->