### PR TITLE
新增週訊息量統計功能

### DIFF
--- a/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/extensions/GenericCommandInteractionEventExtension.kt
+++ b/discord-impl-jda/src/main/kotlin/tw/waterballsa/utopia/jda/extensions/GenericCommandInteractionEventExtension.kt
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 
 fun GenericCommandInteractionEvent.getOptionAsZeroOrPositiveInt(name: String): Int? {
@@ -75,3 +76,6 @@ fun SubcommandData.addRequiredOption(type: OptionType, name: String, description
     addOption(type, name, description, true)
 
 fun IReplyCallback.replyEphemerally(message: String) = reply(message).setEphemeral(true).queue()
+
+fun SlashCommandData.addRequiredOption(type: OptionType, name: String, description: String) =
+    addOption(type, name, description, true)

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -102,6 +102,10 @@
             <groupId>tw.waterballsa.utopia</groupId>
             <artifactId>mongo-gateway</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>weekly-messages-volume</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
+++ b/poll/src/main/kotlin/tw.waterballsa.utopia.poll/PollCommandListener.kt
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import org.springframework.stereotype.Component
 import tw.waterballsa.utopia.commons.extensions.scheduleDelay
 import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.jda.extensions.addRequiredOption
 import tw.waterballsa.utopia.jda.extensions.getOptionAsLongInRange
 import tw.waterballsa.utopia.jda.extensions.getOptionAsStringWithValidation
 import java.awt.Color
@@ -199,6 +200,3 @@ class PollingResult(private val voterIdToVotedOptionIndices: Map<String, Mutable
                     .joinToString(lineSeparator())
         }
 }
-
-private fun SlashCommandData.addRequiredOption(type: OptionType, name: String, description: String) =
-        addOption(type, name, description, true)

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <module>mongo-gateway-impl</module>
         <module>mongo-gateway</module>
         <module>message-cherry-pick</module>
+        <module>weekly-messages-volume</module>
     </modules>
 
     <properties>
@@ -263,6 +264,11 @@
             <dependency>
                 <groupId>tw.waterballsa.utopia</groupId>
                 <artifactId>message-cherry-pick</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>tw.waterballsa.utopia</groupId>
+                <artifactId>weekly-messages-volume</artifactId>
                 <version>${revision}</version>
             </dependency>
         </dependencies>

--- a/weekly-messages-volume/pom.xml
+++ b/weekly-messages-volume/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>tw.waterballsa.utopia</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>weekly-messages-volume</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>discord-impl-jda</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/WeeklyMessageVolumeListener.kt
+++ b/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/WeeklyMessageVolumeListener.kt
@@ -1,0 +1,56 @@
+package tw.waterballsa.utopia.weeklymessagesvolume
+
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.jda.UtopiaListener
+import tw.waterballsa.utopia.jda.extensions.addRequiredOption
+import tw.waterballsa.utopia.jda.extensions.getOptionAsStringWithValidation
+import tw.waterballsa.utopia.jda.extensions.replyEphemerally
+import tw.waterballsa.utopia.weeklymessagesvolume.doamin.WeeklyRange
+
+@Component
+class WeeklyMessageVolumeListener : UtopiaListener() {
+
+    companion object {
+        private const val WEEKLY_MESSAGE_VOLUME = "weekly-messages-volume"
+        private const val CHANNEL_NAME = "channel-name"
+    }
+
+    override fun commands(): List<CommandData> {
+        return listOf(
+            Commands.slash(WEEKLY_MESSAGE_VOLUME, "Show the weekly messages volume of the channel")
+                .addRequiredOption(OptionType.STRING, CHANNEL_NAME, "The channel to show the weekly messages volume")
+        )
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        with(event) {
+            if (fullCommandName != WEEKLY_MESSAGE_VOLUME) {
+                return
+            }
+
+            val channelName = channelName ?: return
+            val textChannel = findTextChannelLikeName(channelName) ?: run {
+                replyEphemerally("cannot find the channel named $channelName.")
+                return
+            }
+
+            val messagesVolume = textChannel.countWeeklyMessages()
+
+            replyEphemerally("The weekly messages volume of the channel ${textChannel.name} is $messagesVolume messages.")
+        }
+    }
+
+    private val SlashCommandInteractionEvent.channelName: String?
+        get() = getOptionAsStringWithValidation(CHANNEL_NAME, "channel name is invalid.") { it.isNotBlank() }
+
+    private fun SlashCommandInteractionEvent.findTextChannelLikeName(channelName: String): TextChannel? =
+        guild?.textChannels?.find { it.name.contains(channelName, ignoreCase = true) }
+}
+
+private fun TextChannel.countWeeklyMessages(): Int =
+    iterableHistory.takeWhile { WeeklyRange().contains(it.timeCreated) }.count()

--- a/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/WeeklyMessagesVolumeListener.kt
+++ b/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/WeeklyMessagesVolumeListener.kt
@@ -13,7 +13,7 @@ import tw.waterballsa.utopia.jda.extensions.replyEphemerally
 import tw.waterballsa.utopia.weeklymessagesvolume.doamin.WeeklyRange
 
 @Component
-class WeeklyMessageVolumeListener : UtopiaListener() {
+class WeeklyMessagesVolumeListener : UtopiaListener() {
 
     companion object {
         private const val WEEKLY_MESSAGE_VOLUME = "weekly-messages-volume"

--- a/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/doamin/WeeklyRange.kt
+++ b/weekly-messages-volume/src/main/kotlin/tw/waterballsa/utopia/weeklymessagesvolume/doamin/WeeklyRange.kt
@@ -1,0 +1,25 @@
+package tw.waterballsa.utopia.weeklymessagesvolume.doamin
+
+import java.time.LocalDate
+import java.time.LocalDate.now
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+/**
+ * 前七天(含今天)的訊息量
+ */
+class WeeklyRange private constructor(
+    private val startDateTime: OffsetDateTime,
+    private val endDateTime: OffsetDateTime
+) {
+    constructor() : this(
+        now().minusDays(7).toTaiwanDateTime(),
+        now().plusDays(1).toTaiwanDateTime()
+    )
+
+    fun contains(dateTime: OffsetDateTime): Boolean =
+        startDateTime.isBefore(dateTime) && dateTime.isBefore(endDateTime)
+}
+
+private fun LocalDate.toTaiwanDateTime(): OffsetDateTime =
+    atStartOfDay().atZone(ZoneId.of("Asia/Taipei")).toOffsetDateTime()


### PR DESCRIPTION
## Why need this change? / Root cause: 
- want count message volume in this week
## Changes made:
- new /weekly-message-volume command
## Test Scope / Change impact:
- none
#137 
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Features:**
- Added a new function `addRequiredOption` to the `SlashCommandData` class for adding required options to slash commands.
- Introduced a new module "weekly-message-volume" with functionality to count weekly message volume in a specific channel using the `/weekly-message-volume` slash command.
- Implemented a `WeekRange` class to calculate the start and end dates of a weekly range.

**Refactor:**
- Replaced the `filter` function with `takeWhile` function in the `cherryPickMessages` function.

> 🎉 With every slash, a command takes flight, 🚀
> Counting messages, day and night. 🌞🌜
> A cherry-picked change, oh so slight, 🍒
> Makes our codebase shine bright! 💡🌟
<!-- end of auto-generated comment: release notes by openai -->