### PR TITLE
dev: setup mongo connection URI

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -18,9 +18,7 @@ jobs:
       - run: |
           flyctl deploy --config fly-beta.toml --remote-only -e \
           BOT_TOKEN=${{ secrets.BOT_TOKEN }},\
-          MONGO_USERNAME=${{ secrets.MONGO_USERNAME }},\
-          MONGO_PASSWORD=${{ secrets.MONGO_PASSWORD }},\
-          MONGO_HOST=${{ secrets.MONGO_HOST }},\
+          MONGO_CONNECTION_URI=${{ secrets.MONGO_CONNECTION_URI }},\
           CHATGPT_TOKEN=${{ secrets.CHATGPT_TOKEN }},\
           DEPLOYMENT_ENV=beta
         env:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -18,6 +18,7 @@ jobs:
       - run: |
           flyctl deploy --config fly-prod.toml --remote-only -e \
           BOT_TOKEN=${{ secrets.BOT_TOKEN }},\
+          MONGO_CONNECTION_URI=${{ secrets.MONGO_CONNECTION_URI }},\
           CHATGPT_TOKEN=${{ secrets.CHATGPT_TOKEN }},\
           DEPLOYMENT_ENV=prod
         env:


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 汰換舊的 mongo connection 設定，使用 GitHub secrets 中的 `MONGO_CONNECTION_URI` environment.
```console
Caused by: com.mongodb.MongoTimeoutException: Timed out after 30000 ms while waiting to connect. Client view of cluster state is {type=UNKNOWN, servers=[{address=localhost:28017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.ConnectException: Connection refused}}] [event body](https://logflare.app/sources/26932/search?querystring=c%3Acount%28%2A%29+c%3Agroup_by%28t%3A%3Aminute%29&tailing%3F=true#)
```
## Changes made:
- 調整 fly.io deploy environment
## Test Scope / Change impact:
- beta WSA bot 可以成功連線至 MongoDB
