### PR TITLE
dev: fly.io environment migration

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -13,14 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-        with:
-          version: 0.1.3
       - run: |
-          flyctl deploy --config fly-beta.toml --remote-only -e \
-          BOT_TOKEN=${{ secrets.BOT_TOKEN }},\
-          MONGO_CONNECTION_URI=${{ secrets.MONGO_CONNECTION_URI }},\
-          CHATGPT_TOKEN=${{ secrets.CHATGPT_TOKEN }},\
-          DEPLOYMENT_ENV=beta
+          flyctl deploy --config fly-beta.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - run: echo "Deploy to fly beta"

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -13,14 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-        with:
-          version: 0.1.3
       - run: |
-          flyctl deploy --config fly-prod.toml --remote-only -e \
-          BOT_TOKEN=${{ secrets.BOT_TOKEN }},\
-          MONGO_CONNECTION_URI=${{ secrets.MONGO_CONNECTION_URI }},\
-          CHATGPT_TOKEN=${{ secrets.CHATGPT_TOKEN }},\
-          DEPLOYMENT_ENV=prod
+          flyctl deploy --config fly-prod.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - run: echo "Deploy to fly prod"

--- a/fly-beta.toml
+++ b/fly-beta.toml
@@ -6,6 +6,7 @@ kill_timeout = 5
 processes = []
 
 [env]
+DEPLOYMENT_ENV= "beta"
 
 [experimental]
 allowed_public_ports = []

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -6,6 +6,7 @@ kill_timeout = 5
 processes = []
 
 [env]
+DEPLOYMENT_ENV= "beta"
 
 [experimental]
 auto_rollback = true

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [env]
-DEPLOYMENT_ENV= "beta"
+DEPLOYMENT_ENV= "prod"
 
 [experimental]
 auto_rollback = true


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 搬遷相關的 environment 至 fly.io 上
- 0.1.3 版 flyctl 已經無法使用，至少需要 0.1.20 以上
- flyctl deploy -e .... 的設定方式目前在切分上有問題，全部的環境變數都不會按照逗號切割

## Changes made:
- 設定 fly.io 各環境的 secrets, env

beta
```
Secrets
NAME                	DIGEST          	CREATED AT          
BOT_TOKEN           	0f31a82ab4978df2	2023-08-01T16:42:27	
CHATGPT_TOKEN       	d793a266dc54ded3	2023-08-01T16:42:27	
MONGO_CONNECTION_URI	7d9f40e3b862038e	2023-08-01T16:42:27	

Environment Variables
NAME          	VALUE 
DEPLOYMENT_ENV	beta 	
```

prod 
```
Secrets
NAME                	DIGEST          	CREATED AT          
BOT_TOKEN           	c58b3ccfc94917af	2023-08-01T16:51:25	
CHATGPT_TOKEN       	d793a266dc54ded3	2023-08-01T16:51:25	
MONGO_CONNECTION_URI	8fef19a47bb24057	2023-08-01T16:53:45	

Environment Variables
NAME          	VALUE                                                                  
DEPLOYMENT_ENV	prod   
```
## Test Scope / Change impact:
-
