### PR TITLE
dev: setup fly.io APP primary region

### DIFF
--- a/fly-beta.toml
+++ b/fly-beta.toml
@@ -2,6 +2,7 @@
 
 app = "wsa-alpha-bot-beta"
 kill_signal = "SIGINT"
+primary_region = "hkg"
 kill_timeout = 5
 processes = []
 

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -2,6 +2,7 @@
 
 app = "wsa-alpha-bot"
 kill_signal = "SIGINT"
+primary_region = "hkg"
 kill_timeout = 5
 processes = []
 


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 目前 MongoDB cluster 建立在台灣，為了降低 latency 滿足 discord interaction 3 秒內需要處理完畢，需要設定 primary region 讓未來機器首先考慮香港
## Changes made:
- 修改 beta, prod 兩份的 fly.io config file
## Test Scope / Change impact:
- 未來新的機器會優先考慮香港
