### PR TITLE
:tada: Increase utopia test kit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>utopia-quiz</module>
         <module>message-cherry-pick</module>
         <module>weekly-messages-volume</module>
+        <module>utopia-test-kit</module>
     </modules>
 
     <properties>

--- a/utopia-test-kit/pom.xml
+++ b/utopia-test-kit/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>tw.waterballsa.utopia</groupId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>utopia-test-kit</artifactId>
+    <name>utopia-test-kit</name>
+    <description>This module is for the utopia test</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>discord-impl-jda</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tw.waterballsa.utopia</groupId>
+            <artifactId>mongo-gateway-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/annotations/UtopiaTest.kt
+++ b/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/annotations/UtopiaTest.kt
@@ -1,0 +1,17 @@
+package tw.waterballsa.utopia.utopiatestkit.annotations
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import tw.waterballsa.utopia.utopiatestkit.configs.MockUtopiaBeanConfig
+import tw.waterballsa.utopia.utopiatestkit.configs.MongoDbTestContainerConfig
+import java.lang.annotation.Inherited
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+
+@Inherited
+@Target(CLASS)
+@Retention(RUNTIME)
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [MockUtopiaBeanConfig::class, MongoDbTestContainerConfig::class])
+annotation class UtopiaTest

--- a/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/configs/MockUtopiaBeanConfig.kt
+++ b/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/configs/MockUtopiaBeanConfig.kt
@@ -1,0 +1,34 @@
+package tw.waterballsa.utopia.utopiatestkit.configs
+
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.mockito.Mockito.*
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
+import tw.waterballsa.utopia.jda.domains.EventPublisher
+import java.util.*
+import java.util.UUID.randomUUID
+
+@Configuration
+@ComponentScan(basePackages = ["tw.waterballsa.utopia"])
+open class MockUtopiaBeanConfig {
+
+    @Bean
+    open fun jda(): JDA = mock(JDA::class.java)
+
+    @Bean
+    open fun guild(): Guild = mock(Guild::class.java)
+
+    @Bean
+    open fun eventPublisher(): EventPublisher = mock(EventPublisher::class.java)
+
+    @Bean
+    open fun wsaDiscordProperties(): WsaDiscordProperties = WsaDiscordProperties(mockProperties())
+
+    @Bean
+    open fun mockProperties(): Properties = mock(Properties::class.java)
+            .apply { `when`(getProperty(anyString())).thenReturn(randomUUID().toString()) }
+
+}

--- a/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/configs/MongoDbTestContainerConfig.kt
+++ b/utopia-test-kit/src/main/koltin/tw/waterballsa/utopia/utopiatestkit/configs/MongoDbTestContainerConfig.kt
@@ -1,0 +1,49 @@
+package tw.waterballsa.utopia.utopiatestkit.configs
+
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.testcontainers.containers.MongoDBContainer
+import java.lang.System.setProperty
+
+@Configuration
+open class MongoDbTestContainerConfig : AbstractMongoClientConfiguration(), BeforeEachCallback, AfterAllCallback {
+
+    companion object {
+        private const val TEST_DATABASE = "TEST_DATABASE"
+        private lateinit var MONGO_DB_CONTAINER: MongoDBContainer
+
+        init {
+            startMongoDBContainer()
+        }
+
+        private fun startMongoDBContainer() {
+            if (!::MONGO_DB_CONTAINER.isInitialized) {
+                MONGO_DB_CONTAINER = MongoDBContainer("mongo:6.0.6")
+                        .withReuse(true)
+                MONGO_DB_CONTAINER.start()
+                setProperty("MONGO_CONNECTION_URI", MONGO_DB_CONTAINER.connectionString)
+            }
+        }
+    }
+
+    @Autowired
+    private lateinit var mongo: MongoTemplate
+
+    override fun getDatabaseName(): String = TEST_DATABASE
+
+    override fun beforeEach(context: ExtensionContext?) {
+        mongo.db.drop()
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        if (!MONGO_DB_CONTAINER.isCreated) {
+            MONGO_DB_CONTAINER.stop()
+        }
+    }
+
+}

--- a/utopia-test-kit/src/test/koltin/tw/waterballsa/utopia/utopiatestkit/UtopiaComponentDiTest.kt
+++ b/utopia-test-kit/src/test/koltin/tw/waterballsa/utopia/utopiatestkit/UtopiaComponentDiTest.kt
@@ -1,0 +1,19 @@
+package tw.waterballsa.utopia.utopiatestkit
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.mongodb.core.MongoTemplate
+import tw.waterballsa.utopia.utopiatestkit.annotations.UtopiaTest
+import tw.waterballsa.utopia.utopiatestkit.components.TestComponent
+
+@UtopiaTest
+class UtopiaComponentDiTest @Autowired constructor(private val factory: BeanFactory) {
+
+    @Test
+    fun testDI() {
+        assertNotNull(factory.getBean(MongoTemplate::class.java))
+        assertNotNull(factory.getBean(TestComponent::class.java))
+    }
+}

--- a/utopia-test-kit/src/test/koltin/tw/waterballsa/utopia/utopiatestkit/components/TestComponent.kt
+++ b/utopia-test-kit/src/test/koltin/tw/waterballsa/utopia/utopiatestkit/components/TestComponent.kt
@@ -1,0 +1,7 @@
+package tw.waterballsa.utopia.utopiatestkit.components
+
+import org.springframework.stereotype.Component
+import tw.waterballsa.utopia.jda.domains.EventPublisher
+
+@Component
+class TestComponent(private val eventPublisher: EventPublisher)


### PR DESCRIPTION
## Why need this change? / Root cause: 
- To test utopia components
## Changes made:
- Increase the annotation **@UtopiaTest** to automatically configure MongoDb test container and some basic mock utopia beans
## Test Scope / Change impact:
- Whole project
