### PR TITLE
feat: fixed audience counter permission problem

### DIFF
--- a/audience-counter/src/main/kotlin/tw/waterballsa/utopia/audiencecounter/AudienceCounterListener.kt
+++ b/audience-counter/src/main/kotlin/tw/waterballsa/utopia/audiencecounter/AudienceCounterListener.kt
@@ -41,14 +41,21 @@ class AudienceCounterListener(private val wsa: WsaDiscordProperties) : UtopiaLis
                 return
             }
 
-            val recordPeriodTime =
-                getOptionAsPositiveInt(TIME_LENGTH)!!.toLong() // period time between startTime and endTime
-            val currentTime = LocalDateTime.now() // now time
-            val startRecordTime = currentTime.truncatedTo(ChronoUnit.MINUTES).toDate() // start time
-            val endRecordTime = currentTime.plusMinutes(recordPeriodTime).toDate() // end time
+            val userRoles = member?.roles?.map { it.id } ?: emptyList()
+            val requiredRole = wsa.wsaAlphaRoleId
 
-            reply("counter start!!!").queue {
-                scheduledRecordHighestAudience(startRecordTime, endRecordTime)
+            if (userRoles.contains(requiredRole)) {
+                val recordPeriodTime =
+                    getOptionAsPositiveInt(TIME_LENGTH)!!.toLong() // period time between startTime and endTime
+                val currentTime = LocalDateTime.now() // now time
+                val startRecordTime = currentTime.truncatedTo(ChronoUnit.MINUTES).toDate() // start time
+                val endRecordTime = currentTime.plusMinutes(recordPeriodTime).toDate() // end time
+
+                reply("counter start!!!").queue {
+                    scheduledRecordHighestAudience(startRecordTime, endRecordTime)
+                }
+            } else {
+                reply("You should be the Alpha!").setEphemeral(true).queue()
             }
         }
     }


### PR DESCRIPTION
## Why need this change? / Root cause: 
The counter command should be used by Alpha.
## Changes made:
-
## Test Scope / Change impact:
if user is Alpha -> run the counter
if user isn't Alpha -> tell the user "You should be the Alpha."
