### PR TITLE
:bug: Fix duplicated bean registry

### DIFF
--- a/utopia-test-kit/src/main/kotlin/tw/waterballsa/utopia/utopiatestkit/configs/MockUtopiaBeanConfig.kt
+++ b/utopia-test-kit/src/main/kotlin/tw/waterballsa/utopia/utopiatestkit/configs/MockUtopiaBeanConfig.kt
@@ -5,13 +5,11 @@ import net.dv8tion.jda.api.entities.Guild
 import org.mockito.Mockito.*
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Configuration
 import tw.waterballsa.utopia.commons.config.WsaDiscordProperties
 import tw.waterballsa.utopia.jda.domains.EventPublisher
 import java.util.*
 import java.util.UUID.randomUUID
 
-@Configuration
 @ComponentScan(basePackages = ["tw.waterballsa.utopia"])
 open class MockUtopiaBeanConfig {
 


### PR DESCRIPTION
## Why need this change? / Root cause: 
- To fix duplicated bean registry
## Changes made:
- Won't register bean duplicately
## Test Scope / Change impact:
- Whole project
